### PR TITLE
Fixed sync of notes with <p> in code.

### DIFF
--- a/html/enmlformatter.cpp
+++ b/html/enmlformatter.cpp
@@ -418,7 +418,6 @@ void EnmlFormatter::removeInvalidAttributes(QWebElement &node) {
 void EnmlFormatter::postXmlFix() {
 
     int pos;
-    content = content.replace("<p>", "<p/>");
     content = content.replace("<hr>", "<hr/>");
 
     // Fix the <br> tags
@@ -469,7 +468,6 @@ void EnmlFormatter::postXmlFix() {
         }
         pos = content.indexOf("<en-media", pos+1);
     }
-
 }
 
 


### PR DESCRIPTION
My notes with `<p>...</p>` in the code doesn't sync after being modified, I get the following message:

```
 [...] ( nixnote.cpp @ 1564 ) "Unable to update note.  Invalid note structure : "
```

I found what caused the problem and the fix was removing the line replacing all `<p>` with `</p>` in `void EnmlFormatter::postXmlFix()`

I think I found the commit that introduced this behavior 35b8d2829db4f4c0d9c0f3da67298d16b7674caf and the reasoning in the comment above the code is that any tags that doesn't end with `\>` will break the Qt parser. 

Removing this line did not introduce any new problems for me, I tried adding a faulty lone `<p>` without an `</p>` and the syncing still worked for me because Tidy caught this:

```
[...] ( html/enmlformatter.cpp @ 89 ) Tidy Errors: "line 9 column 109 - Warning: trimming empty <p>
```

When I inserted `<p/>` in the code Tidy seemed to just remove it with the same message as above.

Being completely new to the project I might have missed something, but I think it is safe to remove this line because Tidy catches any fixes any problems with `<p>` anyway.
