### PR TITLE
fix exception during synchronization due to access to unset note's title

### DIFF
--- a/sql/notetable.cpp
+++ b/sql/notetable.cpp
@@ -148,7 +148,7 @@ qint32 NoteTable::add(qint32 l, const Note &t, bool isDirty, qint32 account) {
     if (lid <= 0)
         lid = cs.incrementLidCounter();
 
-    QLOG_DEBUG() << "Adding note("<<lid<<") " << t.title;
+    QLOG_DEBUG() << "Adding note("<<lid<<") " << (t.title.isSet() ? t.title : "title is empty");
     if (t.guid.isSet()) {
         QString guid = t.guid;
         query.bindValue(":lid", lid);


### PR DESCRIPTION
Hi! Thanks a lot for Nixnote2, it's great software!

I found one bug during the synchronization, it went down with exception due to access to nonexistent Note's title in the log entry. Fix was simple enough.
