### PR TITLE
set correct font size according to DPI for WebKit

### DIFF
--- a/dialog/preferences/appearancepreferences.cpp
+++ b/dialog/preferences/appearancepreferences.cpp
@@ -22,6 +22,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #include <QFontDatabase>
 #include <QWebSettings>
+#include <QtGui/QDesktopWidget>
+#include <QApplication>
 
 extern Global global;
 
@@ -162,7 +164,11 @@ void AppearancePreferences::saveValues() {
 
         QWebSettings *settings = QWebSettings::globalSettings();
         settings->setFontFamily(QWebSettings::StandardFont, global.defaultFont);
-        settings->setFontSize(QWebSettings::DefaultFontSize, global.defaultFontSize);
+        // QWebkit DPI is hard coded to 96. Hence, we calculate the correct
+        // font size based on desktop logical DPI.
+        settings->setFontSize(QWebSettings::DefaultFontSize,
+            global.defaultFontSize * (QApplication::desktop()->logicalDpiX() / 96.0)
+            );
     }
 
 

--- a/global.cpp
+++ b/global.cpp
@@ -23,6 +23,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <limits.h>
 #include <unistd.h>
 #include <QWebSettings>
+#include <QtGui/QDesktopWidget>
+#include <QApplication>
 
 
 //******************************************
@@ -130,7 +132,11 @@ void Global::setup(StartupConfig startupConfig) {
     if (defaultFont != "" && defaultFontSize > 0) {
         QWebSettings *settings = QWebSettings::globalSettings();
         settings->setFontFamily(QWebSettings::StandardFont, defaultFont);
-        settings->setFontSize(QWebSettings::DefaultFontSize, defaultFontSize);
+        // QWebkit DPI is hard coded to 96. Hence, we calculate the correct
+        // font size based on desktop logical DPI.
+        settings->setFontSize(QWebSettings::DefaultFontSize,
+            defaultFontSize * (QApplication::desktop()->logicalDpiX() / 96.0)
+            );
     }
 
 }


### PR DESCRIPTION
Now the note content web view will have correct (uniform) font size on HiDPI desktops as well.

c.f. KDE project (Telepathy): https://projects.kde.org/projects/extragear/network/telepathy/ktp-text-ui/repository/revisions/f5e12db4e09b0068766bf2bf6134728e1a8b9ea6/diff/lib/adium-theme-view.cpp