### PR TITLE
crash for global.indexRunner is null

### DIFF
--- a/nixnote.cpp
+++ b/nixnote.cpp
@@ -773,6 +773,7 @@ void NixNote::syncThreadStarted() {
 void NixNote::indexThreadStarted() {
     indexRunner.moveToThread(&indexThread);
     indexRunner.initialize();
+    global.indexRunner = &indexRunner;
 }
 
 


### PR DESCRIPTION
global.indexRunner is not initialized correctly.