### PR TITLE
fix some translation errors for zh_CN

### DIFF
--- a/package_scripts/gentoo.sh
+++ b/package_scripts/gentoo.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 version="2.0-beta4"
+eversion="2.0_beta4"
 package_dir=$(cd `dirname $0` && pwd)
 
 
@@ -25,15 +26,15 @@ echo "**************************************************"
 
 # Cleanup any old stuff
 
-if [ -e "$package_dir/nixnote2-${version}.ebuild" ] 
+if [ -e "$package_dir/nixnote2-${eversion}.ebuild" ] 
 then
-   rm $package_dir/nixnote2-${version}.ebuild
+   rm $package_dir/nixnote2-${eversion}.ebuild
 fi
 
-cp $package_dir/gentoo/ebuild $package_dir/nixnote2-${version}.ebuild
+cp $package_dir/gentoo/ebuild $package_dir/nixnote2-${eversion}.ebuild
 
 
 #edit the spec file to update the version & architecture
-sed -i "s/__TAG__/$tag/g" $package_dir/nixnote2-${version}.ebuild
-sed -i "s/__VERSION__/$version/g" $package_dir/nixnote2-${version}.ebuild
+sed -i "s/__TAG__/$tag/g" $package_dir/nixnote2-${eversion}.ebuild
+sed -i "s/__VERSION__/$version/g" $package_dir/nixnote2-${eversion}.ebuild
 

--- a/package_scripts/gentoo/ebuild
+++ b/package_scripts/gentoo/ebuild
@@ -4,50 +4,71 @@
 
 EAPI=5
 
+inherit qmake-utils
+
+
+if [[ "${PV}" == "9999" ]] ; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/baumgarr/Nixnote2.git"
+	SLOT="0/9999"
+else
+	SRC_URI="https://github.com/baumgarr/Nixnote2/archive/__TAG__.tar.gz -> Nixnote2-__VERSION__.tar.gz"
+	SLOT="0/2"   
+	S="${WORKDIR}/Nixnote2-__VERSION__"
+fi
+
 DESCRIPTION="Nixnote - A clone of Evernote for Linux"
 HOMEPAGE="http://sourceforge.net/projects/nevernote/"
-SRC_URI="https://github.com/baumgarr/Nixnote2/archive/__TAG__.tar.gz -> Nixnote2-__VERSION__.tar.gz"
-
 LICENSE="GPL-2"
-SLOT="0"
-KEYWORDS="~amd64"
-IUSE=""
+KEYWORDS="~amd64 ~x86"
+IUSE="qt4 qt5"
 
-DEPEND="app-text/poppler
-dev-qt/qtwebkit:4
-dev-qt/qtcore:4
-dev-qt/qtgui:4
-dev-qt/qtsql:4
-"
-RDEPEND="${DEPEND}"
-
-S="${WORKDIR}/Nixnote2-__VERSION__"
+REQUIRED_USE="^^ ( qt4 qt5 )"
+		
+DEPEND="dev-libs/boost
+	      app-text/hunspell
+	      media-libs/opencv:0/2.4
+	      qt4? (
+		      app-text/poppler[qt4]
+		      dev-qt/qtwebkit:4
+		      dev-qt/qtcore:4
+		      dev-qt/qtgui:4
+		      dev-qt/qtsql:4
+	      )
+	      qt5? (
+		      app-text/poppler[qt5]
+		      dev-qt/qtwebkit:5
+		      dev-qt/qtcore:5
+		      dev-qt/qtgui:5
+		      dev-qt/qtsql:5
+	      )
+	      "
+RDEPEND="${DEPEND}
+		app-text/htmltidy"
 
 src_prepare() {
-	/usr/lib64/qt4/bin/qmake -o Makefile NixNote2.pro
+
+	lrelease NixNote2.pro
+	
+	if use qt4; then
+		eqmake4 NixNote2.pro
+	fi
+	if use qt5; then
+		eqmake5 NixNote2.pro
+	fi
 }
 
 src_install() {
-	mkdir -p ${D}/usr/share/nixnote2
+	insinto /usr/share/nixnote2
+	doins -r certs help images java qss translations changelog.txt license.html shortcuts.txt *.ini
 
-	cp -r \
-	certs \
-  	help \
-   	images \
-   	java \
- 	qss \
-  	translations \
-	${D}/usr/share/nixnote2
-
-	cp \
-	changelog.txt \
-	license.html \
-	shortcuts.txt \
-	${D}/usr/share/nixnote2
+	rm -r ${D}/usr/share/nixnote2/translations/*.ts
 	
-	mkdir -p ${D}/usr/bin
-	cp nixnote2 ${D}/usr/bin/
+	dobin nixnote2
+	
+	insinto /usr/share/applications
+	doins nixnote2.desktop
+	
+	doman ${S}/man/nixnote2.1
 
-	mkdir -p ${D}/usr/share/applications
-	cp nixnote2.desktop ${D}/usr/share/applications/
 }

--- a/translations/nixnote2_zh_CN.ts
+++ b/translations/nixnote2_zh_CN.ts
@@ -14,88 +14,97 @@
     <message>
         <location filename="../dialog/accountdialog.cpp" line="37"/>
         <source>Account Information</source>
-        <translation type="unfinished">账户信息</translation>
+        <translation>账户信息</translation>
+    </message>
+    <message>
+        <source>Free</source>
+        <translation type="obsolete">免费</translation>
     </message>
     <message>
         <location filename="../dialog/accountdialog.cpp" line="40"/>
-        <source>Free</source>
-        <translation type="unfinished">免费</translation>
+        <source>Normal</source>
+        <translation>免费</translation>
     </message>
     <message>
         <location filename="../dialog/accountdialog.cpp" line="46"/>
         <source>Premium</source>
         <translatorcomment>Evernote has only two types of account, but yixiang note in China has three(Free, Standard and Premium).</translatorcomment>
-        <translation type="unfinished">高级</translation>
+        <translation>标准</translation>
     </message>
     <message>
         <location filename="../dialog/accountdialog.cpp" line="48"/>
-        <source>Manager</source>
-        <translation type="unfinished">管理</translation>
+        <source>VIP</source>
+        <translation>高级</translation>
     </message>
     <message>
         <location filename="../dialog/accountdialog.cpp" line="50"/>
-        <source>Support</source>
-        <translation type="unfinished">支持</translation>
+        <source>Manager</source>
+        <translation>管理</translation>
     </message>
     <message>
         <location filename="../dialog/accountdialog.cpp" line="52"/>
+        <source>Support</source>
+        <translation>支持</translation>
+    </message>
+    <message>
+        <location filename="../dialog/accountdialog.cpp" line="54"/>
         <source>Admin</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">管理员</translation>
     </message>
     <message>
-        <location filename="../dialog/accountdialog.cpp" line="73"/>
+        <location filename="../dialog/accountdialog.cpp" line="75"/>
         <source> Bytes</source>
-        <translation type="unfinished"> Bytes</translation>
+        <translation> Bytes</translation>
     </message>
     <message>
-        <location filename="../dialog/accountdialog.cpp" line="77"/>
+        <location filename="../dialog/accountdialog.cpp" line="79"/>
         <source> KB</source>
-        <translation type="unfinished"> KB</translation>
+        <translation> KB</translation>
     </message>
     <message>
-        <location filename="../dialog/accountdialog.cpp" line="81"/>
+        <location filename="../dialog/accountdialog.cpp" line="83"/>
         <source> MB</source>
-        <translation type="unfinished"> MB</translation>
+        <translation> MB</translation>
     </message>
     <message>
-        <location filename="../dialog/accountdialog.cpp" line="88"/>
+        <location filename="../dialog/accountdialog.cpp" line="90"/>
         <source>Account:</source>
-        <translation type="unfinished">账户：</translation>
-    </message>
-    <message>
-        <location filename="../dialog/accountdialog.cpp" line="91"/>
-        <source>User Name:</source>
-        <translation type="unfinished">用户名：</translation>
+        <translation>账户：</translation>
     </message>
     <message>
         <location filename="../dialog/accountdialog.cpp" line="93"/>
-        <source>Account Type:</source>
-        <translation type="unfinished">账户类型：</translation>
+        <source>User Name:</source>
+        <translation>用户名：</translation>
     </message>
     <message>
         <location filename="../dialog/accountdialog.cpp" line="95"/>
-        <source>Limit:</source>
-        <translation type="unfinished">流量限额：</translation>
+        <source>Account Type:</source>
+        <translation>账户类型：</translation>
     </message>
     <message>
         <location filename="../dialog/accountdialog.cpp" line="97"/>
+        <source>Limit:</source>
+        <translation>流量限额：</translation>
+    </message>
+    <message>
+        <location filename="../dialog/accountdialog.cpp" line="99"/>
         <source>Uploaded In This Period:</source>
-        <translation type="unfinished">本期已上传流量：</translation>
+        <translation>本期已上传流量：</translation>
     </message>
     <message>
-        <location filename="../dialog/accountdialog.cpp" line="101"/>
+        <location filename="../dialog/accountdialog.cpp" line="103"/>
         <source>Less than 1MB</source>
-        <translation type="unfinished">小于1MB</translation>
+        <translation>小于1MB</translation>
     </message>
     <message>
-        <location filename="../dialog/accountdialog.cpp" line="102"/>
+        <location filename="../dialog/accountdialog.cpp" line="104"/>
         <source>Current Cycle Ends:</source>
-        <translation type="unfinished">本期结束日期：</translation>
+        <translation>本期结束日期：</translation>
     </message>
     <message>
-        <location filename="../dialog/accountdialog.cpp" line="110"/>
+        <location filename="../dialog/accountdialog.cpp" line="112"/>
         <source>OK</source>
-        <translation type="unfinished">确定</translation>
+        <translation>确定</translation>
     </message>
 </context>
 <context>
@@ -103,53 +112,53 @@
     <message>
         <location filename="../dialog/accountmaintenancedialog.cpp" line="34"/>
         <source>OK</source>
-        <translation type="unfinished">确定</translation>
+        <translation>确定</translation>
     </message>
     <message>
         <location filename="../dialog/accountmaintenancedialog.cpp" line="35"/>
         <source>Close</source>
-        <translation type="unfinished">关闭</translation>
+        <translation>关闭</translation>
     </message>
     <message>
         <location filename="../dialog/accountmaintenancedialog.cpp" line="36"/>
         <source>Add</source>
-        <translation type="unfinished">添加</translation>
+        <translation>添加</translation>
     </message>
     <message>
         <location filename="../dialog/accountmaintenancedialog.cpp" line="37"/>
         <source>Rename</source>
-        <translation type="unfinished">重命名</translation>
+        <translation>重命名</translation>
     </message>
     <message>
         <location filename="../dialog/accountmaintenancedialog.cpp" line="38"/>
         <source>Delete</source>
-        <translation type="unfinished">删除</translation>
+        <translation>删除</translation>
     </message>
     <message>
         <location filename="../dialog/accountmaintenancedialog.cpp" line="64"/>
         <source>User Account Maintenance</source>
-        <translation type="unfinished">用户账户管理</translation>
+        <translation>用户账户管理</translation>
     </message>
     <message>
         <location filename="../dialog/accountmaintenancedialog.cpp" line="104"/>
         <source>Are you sure you want to delete this account?</source>
-        <translation type="unfinished">确定删除这个账户？</translation>
+        <translation>确定删除这个账户？</translation>
     </message>
     <message>
         <location filename="../dialog/accountmaintenancedialog.cpp" line="105"/>
         <source>Verify Delete</source>
-        <translation type="unfinished">删除确认</translation>
+        <translation>删除确认</translation>
     </message>
     <message>
         <location filename="../dialog/accountmaintenancedialog.cpp" line="117"/>
         <source>You cannot delete the active account.</source>
-        <translation type="unfinished">不能删除在用账户。</translation>
+        <translation>不能删除在用账户。</translation>
     </message>
     <message>
         <location filename="../dialog/accountmaintenancedialog.cpp" line="170"/>
         <location filename="../dialog/accountmaintenancedialog.cpp" line="194"/>
         <source>Switch to </source>
-        <translation type="unfinished">切换到</translation>
+        <translation>切换到</translation>
     </message>
 </context>
 <context>
@@ -157,37 +166,37 @@
     <message>
         <location filename="../dialog/adduseraccountdialog.cpp" line="38"/>
         <source>Server</source>
-        <translation type="unfinished">服务器</translation>
+        <translation>服务器</translation>
     </message>
     <message>
         <location filename="../dialog/adduseraccountdialog.cpp" line="39"/>
         <source>OK</source>
-        <translation type="unfinished">确定</translation>
+        <translation>确定</translation>
     </message>
     <message>
         <location filename="../dialog/adduseraccountdialog.cpp" line="41"/>
         <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
+        <translation>取消</translation>
     </message>
     <message>
         <location filename="../dialog/adduseraccountdialog.cpp" line="46"/>
         <source>Account Name</source>
-        <translation type="unfinished">账户名</translation>
+        <translation>账户名</translation>
     </message>
     <message>
         <location filename="../dialog/adduseraccountdialog.cpp" line="69"/>
         <source>Evernote</source>
-        <translation type="unfinished">Evernote</translation>
+        <translation>Evernote国际版</translation>
     </message>
     <message>
         <location filename="../dialog/adduseraccountdialog.cpp" line="70"/>
         <source>Yinxiang Biji</source>
-        <translation type="unfinished">印象笔记</translation>
+        <translation>印象笔记</translation>
     </message>
     <message>
         <location filename="../dialog/adduseraccountdialog.cpp" line="71"/>
         <source>Evernote Sandbox</source>
-        <translation type="unfinished">Evernote沙盒</translation>
+        <translation>Evernote沙盒</translation>
     </message>
 </context>
 <context>
@@ -195,7 +204,7 @@
     <message>
         <location filename="../dialog/preferences/appearancepreferences.cpp" line="39"/>
         <source>Show tray icon</source>
-        <translation type="unfinished">显示托盘图标</translation>
+        <translation>显示托盘图标</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/appearancepreferences.cpp" line="40"/>
@@ -205,173 +214,193 @@
     <message>
         <location filename="../dialog/preferences/appearancepreferences.cpp" line="41"/>
         <source>Show splash screen on startup</source>
-        <translation type="unfinished">启动时显示欢迎界面</translation>
+        <translation>启动时显示欢迎界面</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/appearancepreferences.cpp" line="42"/>
         <source>Start automatically at login</source>
-        <translation type="unfinished">系统登录时自动启动</translation>
+        <translation>系统登录时自动启动</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/appearancepreferences.cpp" line="43"/>
         <source>Confirm Deletes</source>
-        <translation type="unfinished">删除确认</translation>
+        <translation>删除时确认</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/appearancepreferences.cpp" line="44"/>
         <source>Show missed reminders on startup</source>
-        <translation type="unfinished">启动时显示错过的提醒事项</translation>
+        <translation>启动时显示错过的提醒事项</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/appearancepreferences.cpp" line="45"/>
         <source>Always Start minimized</source>
-        <translation type="unfinished">启动时最小化</translation>
+        <translation>启动时最小化</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/appearancepreferences.cpp" line="46"/>
         <source>Show notebook and tag totals</source>
-        <translation type="unfinished">显示笔记本和标签计数</translation>
+        <translation>显示笔记本和标签计数</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/appearancepreferences.cpp" line="47"/>
         <source>Auto-Hide editor toolbar</source>
-        <translation type="unfinished">自动隐藏编辑工具栏</translation>
+        <translation>自动隐藏编辑工具栏</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/appearancepreferences.cpp" line="49"/>
         <source>Disable note editing on statup</source>
-        <translation type="unfinished">启动时禁用笔记编辑</translation>
+        <translation>启动时禁用笔记编辑</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/appearancepreferences.cpp" line="50"/>
         <source>Focus on Note Title on New Note</source>
-        <translation type="unfinished">新建笔记时光标位于笔记标题</translation>
+        <translation>新建笔记时光标位于笔记标题</translation>
     </message>
     <message>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="53"/>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="59"/>
-        <source>Show/Hide NixNote</source>
-        <translation type="unfinished">显示/隐藏 NixNote</translation>
-    </message>
-    <message>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="54"/>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="60"/>
-        <source>New Text Note</source>
-        <translation type="unfinished">新建文本笔记</translation>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="51"/>
+        <source>Limit Editor to Web Fonts*</source>
+        <translation type="unfinished">编辑器只使用Web字体</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/appearancepreferences.cpp" line="55"/>
         <location filename="../dialog/preferences/appearancepreferences.cpp" line="61"/>
-        <source>New Quick Note</source>
-        <translatorcomment>I got crash when click &quot;New Quick Note&quot;, so I don&apos;t know what quick note really mean.</translatorcomment>
-        <translation type="unfinished">新建快速笔记</translation>
+        <source>Show/Hide NixNote</source>
+        <translation>显示/隐藏 NixNote</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/appearancepreferences.cpp" line="56"/>
         <location filename="../dialog/preferences/appearancepreferences.cpp" line="62"/>
+        <source>New Text Note</source>
+        <translation>新建文本笔记</translation>
+    </message>
+    <message>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="57"/>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="63"/>
+        <source>New Quick Note</source>
+        <translatorcomment>I got crash when click &quot;New Quick Note&quot;, so I don&apos;t know what quick note really mean.</translatorcomment>
+        <translation>新建快速笔记</translation>
+    </message>
+    <message>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="58"/>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="64"/>
         <source>Screen Capture</source>
-        <translation type="unfinished">屏幕截图</translation>
+        <translation>屏幕截图</translation>
     </message>
     <message>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="65"/>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="67"/>
         <source>Open New Tab</source>
-        <translation type="unfinished">在新标签页打开</translation>
+        <translation>在新标签页打开</translation>
     </message>
     <message>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="66"/>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="68"/>
         <source>Open New Window</source>
-        <translation type="unfinished">在新窗口打开</translation>
+        <translation>在新窗口打开</translation>
     </message>
     <message>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="85"/>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="83"/>
+        <source>Qt Default</source>
+        <translation>Qt默认</translation>
+    </message>
+    <message>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="84"/>
+        <source>notify-send</source>
+        <translation type="unfinished">notify-send</translation>
+    </message>
+    <message>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="91"/>
         <source>Startup Behavior</source>
-        <translation type="unfinished">启动时</translation>
+        <translation>启动时</translation>
     </message>
     <message>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="87"/>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="93"/>
         <source>Restore Selection Criteria</source>
-        <translation type="unfinished">恢复上次打开笔记</translation>
+        <translation>恢复上次打开笔记</translation>
     </message>
     <message>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="88"/>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="94"/>
         <source>Select Default Notebook</source>
-        <translation type="unfinished">打开默认笔记本</translation>
+        <translation>打开默认笔记本</translation>
     </message>
     <message>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="89"/>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="95"/>
         <source>View All Notebooks</source>
-        <translation type="unfinished">浏览所有笔记本</translation>
+        <translation>浏览所有笔记本</translation>
     </message>
     <message>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="99"/>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="105"/>
         <source>Minimize to tray</source>
-        <translation type="unfinished">最小化到托盘</translation>
+        <translation>最小化到托盘</translation>
     </message>
     <message>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="100"/>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="106"/>
         <source>Close to tray</source>
-        <translation type="unfinished">关闭到托盘</translation>
+        <translation>关闭到托盘</translation>
     </message>
     <message>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="117"/>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="124"/>
+        <source>Notification Service</source>
+        <translation>通知服务</translation>
+    </message>
+    <message>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="127"/>
         <source>Middle Click Open Behavior</source>
-        <translation type="unfinished">中键单击笔记</translation>
+        <translation>中键单击笔记</translation>
     </message>
     <message>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="120"/>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="130"/>
         <source>Tray Icon Click Action</source>
-        <translation type="unfinished">单击托盘图标</translation>
+        <translation>单击托盘图标</translation>
     </message>
     <message>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="123"/>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="133"/>
         <source>Tray Icon Middle Click Action</source>
-        <translation type="unfinished">中键单击托盘图标</translation>
+        <translation>中键单击托盘图标</translation>
     </message>
     <message>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="126"/>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="136"/>
         <source>Default GUI Font*</source>
-        <translation type="unfinished">默认显示字体</translation>
-    </message>
-    <message>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="129"/>
-        <source>Default GUI Font Size*</source>
-        <translation type="unfinished">默认显示字号</translation>
-    </message>
-    <message>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="132"/>
-        <source>Default Editor Font*</source>
-        <translation type="unfinished">默认编辑字体</translation>
-    </message>
-    <message>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="135"/>
-        <source>Default Editor Font Size*</source>
-        <translation type="unfinished">默认编辑字号</translation>
+        <translation>默认显示字体</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/appearancepreferences.cpp" line="139"/>
-        <source>* May require restart on some systems.</source>
-        <translation type="unfinished">在一些系统中可能需要重启NixNote才能生效。</translation>
+        <source>Default GUI Font Size*</source>
+        <translation>默认显示字号</translation>
     </message>
     <message>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="81"/>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="339"/>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="357"/>
-        <location filename="../dialog/preferences/appearancepreferences.cpp" line="376"/>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="142"/>
+        <source>Default Editor Font*</source>
+        <translation>默认编辑字体</translation>
+    </message>
+    <message>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="145"/>
+        <source>Default Editor Font Size*</source>
+        <translation>默认编辑字号</translation>
+    </message>
+    <message>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="149"/>
+        <source>* May require restart on some systems.</source>
+        <translation>*在一些系统中可能需要重启NixNote才能生效。</translation>
+    </message>
+    <message>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="87"/>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="367"/>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="385"/>
+        <location filename="../dialog/preferences/appearancepreferences.cpp" line="404"/>
         <source>System Default</source>
-        <translation type="unfinished">系统默认</translation>
+        <translation>系统默认</translation>
     </message>
 </context>
 <context>
     <name>AttachmentIconBuilder</name>
     <message>
-        <location filename="../html/attachmenticonbuilder.cpp" line="73"/>
+        <location filename="../html/attachmenticonbuilder.cpp" line="74"/>
         <source>Bytes</source>
-        <translation type="unfinished">Bytes</translation>
+        <translation>Bytes</translation>
     </message>
     <message>
-        <location filename="../html/attachmenticonbuilder.cpp" line="77"/>
+        <location filename="../html/attachmenticonbuilder.cpp" line="78"/>
         <source>KB</source>
-        <translation type="unfinished">KB</translation>
+        <translation>KB</translation>
     </message>
 </context>
 <context>
@@ -379,7 +408,15 @@
     <message>
         <location filename="../gui/browserWidgets/authoreditor.cpp" line="37"/>
         <source>Click to set author</source>
-        <translation type="unfinished">点击设置作者</translation>
+        <translation>点击设置作者</translation>
+    </message>
+</context>
+<context>
+    <name>BatchImport</name>
+    <message>
+        <location filename="../xml/batchimport.cpp" line="75"/>
+        <source>Untitled Note</source>
+        <translation>未命名笔记</translation>
     </message>
 </context>
 <context>
@@ -387,74 +424,132 @@
     <message>
         <location filename="../dialog/closenotebookdialog.cpp" line="37"/>
         <source>Open/Close Notebooks</source>
-        <translation type="unfinished">打开/关闭笔记本</translation>
+        <translation>打开/关闭笔记本</translation>
     </message>
     <message>
         <location filename="../dialog/closenotebookdialog.cpp" line="42"/>
         <source>OK</source>
-        <translation type="unfinished">确定</translation>
+        <translation>确定</translation>
     </message>
     <message>
         <location filename="../dialog/closenotebookdialog.cpp" line="43"/>
         <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
+        <translation>取消</translation>
     </message>
     <message>
         <location filename="../dialog/closenotebookdialog.cpp" line="56"/>
         <source>Open Notebooks</source>
-        <translation type="unfinished">已打开笔记本</translation>
+        <translation>已打开笔记本</translation>
     </message>
     <message>
         <location filename="../dialog/closenotebookdialog.cpp" line="57"/>
         <source>Closed Notebooks</source>
-        <translation type="unfinished">已关闭笔记本</translation>
+        <translation>已关闭笔记本</translation>
     </message>
     <message>
         <location filename="../dialog/closenotebookdialog.cpp" line="59"/>
         <source>Open</source>
-        <translation type="unfinished">打开</translation>
+        <translation>打开</translation>
     </message>
     <message>
         <location filename="../dialog/closenotebookdialog.cpp" line="60"/>
         <source>Close</source>
-        <translation type="unfinished">关闭</translation>
+        <translation>关闭</translation>
+    </message>
+</context>
+<context>
+    <name>ColorSettings</name>
+    <message>
+        <location filename="../settings/colorsettings.cpp" line="37"/>
+        <source>White</source>
+        <translation>白色</translation>
+    </message>
+    <message>
+        <location filename="../settings/colorsettings.cpp" line="38"/>
+        <source>Red</source>
+        <translation>红色</translation>
+    </message>
+    <message>
+        <location filename="../settings/colorsettings.cpp" line="39"/>
+        <source>Blue</source>
+        <translation>蓝色</translation>
+    </message>
+    <message>
+        <location filename="../settings/colorsettings.cpp" line="40"/>
+        <source>Green</source>
+        <translation>绿色</translation>
+    </message>
+    <message>
+        <location filename="../settings/colorsettings.cpp" line="41"/>
+        <source>Yellow</source>
+        <translation>黄色</translation>
+    </message>
+    <message>
+        <location filename="../settings/colorsettings.cpp" line="42"/>
+        <source>Black</source>
+        <translation>黑色</translation>
+    </message>
+    <message>
+        <location filename="../settings/colorsettings.cpp" line="43"/>
+        <source>Purple</source>
+        <translation>紫色</translation>
+    </message>
+    <message>
+        <location filename="../settings/colorsettings.cpp" line="44"/>
+        <source>Brown</source>
+        <translation>棕色</translation>
+    </message>
+    <message>
+        <location filename="../settings/colorsettings.cpp" line="45"/>
+        <source>Orange</source>
+        <translation>橙色</translation>
+    </message>
+    <message>
+        <location filename="../settings/colorsettings.cpp" line="46"/>
+        <source>Grey</source>
+        <translation>灰色</translation>
+    </message>
+    <message>
+        <location filename="../settings/colorsettings.cpp" line="47"/>
+        <source>Powder Blue</source>
+        <translation>浅蓝</translation>
     </message>
 </context>
 <context>
     <name>CommunicationManager</name>
     <message>
-        <location filename="../communication/communicationmanager.cpp" line="606"/>
+        <location filename="../communication/communicationmanager.cpp" line="622"/>
         <source>Linked notebook notestore URL missing.</source>
         <translation type="unfinished">笔记缺失链接的URL。</translation>
     </message>
     <message>
-        <location filename="../communication/communicationmanager.cpp" line="1074"/>
-        <location filename="../communication/communicationmanager.cpp" line="1076"/>
+        <location filename="../communication/communicationmanager.cpp" line="1097"/>
+        <location filename="../communication/communicationmanager.cpp" line="1099"/>
         <source>API rate limit exceeded.  Please try again in </source>
         <translation type="unfinished">API比例超出限制。请在以下时间内重试：</translation>
     </message>
     <message>
-        <location filename="../communication/communicationmanager.cpp" line="1074"/>
+        <location filename="../communication/communicationmanager.cpp" line="1097"/>
         <source> minutes.</source>
         <translation type="unfinished"> 分钟。</translation>
     </message>
     <message>
-        <location filename="../communication/communicationmanager.cpp" line="1076"/>
+        <location filename="../communication/communicationmanager.cpp" line="1099"/>
         <source> minute.</source>
         <translation type="unfinished"> 分钟。</translation>
     </message>
     <message>
-        <location filename="../communication/communicationmanager.cpp" line="1080"/>
+        <location filename="../communication/communicationmanager.cpp" line="1103"/>
         <source>EDAMSystemException </source>
         <translation type="unfinished">EDAM系统异常 </translation>
     </message>
     <message>
-        <location filename="../communication/communicationmanager.cpp" line="1082"/>
+        <location filename="../communication/communicationmanager.cpp" line="1105"/>
         <source>EDAMSystemException: Unknown error</source>
         <translation type="unfinished">EDAM系统异常：未知错误</translation>
     </message>
     <message>
-        <location filename="../communication/communicationmanager.cpp" line="1103"/>
+        <location filename="../communication/communicationmanager.cpp" line="1126"/>
         <source>EDAMNotFoundException: Note not found</source>
         <translation type="unfinished">EDAMNotFound异常：未找到笔记</translation>
     </message>
@@ -464,12 +559,12 @@
     <message>
         <location filename="../dialog/databasestatus.cpp" line="35"/>
         <source>Database Status</source>
-        <translation type="unfinished">数据库状态</translation>
+        <translation>数据库状态</translation>
     </message>
     <message>
         <location filename="../dialog/databasestatus.cpp" line="47"/>
         <source>Total Notes:</source>
-        <translation type="unfinished">总笔记数：</translation>
+        <translation>总笔记数：</translation>
     </message>
     <message>
         <location filename="../dialog/databasestatus.cpp" line="49"/>
@@ -480,7 +575,7 @@
     <message>
         <location filename="../dialog/databasestatus.cpp" line="51"/>
         <source>Unindexed Notes:</source>
-        <translation type="unfinished">未索引笔记：</translation>
+        <translation>未索引笔记：</translation>
     </message>
     <message>
         <location filename="../dialog/databasestatus.cpp" line="53"/>
@@ -490,12 +585,12 @@
     <message>
         <location filename="../dialog/databasestatus.cpp" line="55"/>
         <source>Thumbnails Needed:</source>
-        <translation type="unfinished">需要缩略图：</translation>
+        <translation type="unfinished">缩略图数：</translation>
     </message>
     <message>
         <location filename="../dialog/databasestatus.cpp" line="60"/>
         <source>OK</source>
-        <translation type="unfinished">确定</translation>
+        <translation>确定</translation>
     </message>
 </context>
 <context>
@@ -503,7 +598,7 @@
     <message>
         <location filename="../gui/datedelegate.cpp" line="42"/>
         <source>Today</source>
-        <translation type="unfinished">今天</translation>
+        <translation>今天</translation>
     </message>
 </context>
 <context>
@@ -511,17 +606,17 @@
     <message>
         <location filename="../gui/browserWidgets/dateeditor.cpp" line="38"/>
         <source>Created:</source>
-        <translation type="unfinished">创建时间：</translation>
+        <translation>创建时间：</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/dateeditor.cpp" line="42"/>
         <source>Updated:</source>
-        <translation type="unfinished">最后更新：</translation>
+        <translation>最后更新：</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/dateeditor.cpp" line="46"/>
         <source>Subject:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">主题时间：</translation>
     </message>
 </context>
 <context>
@@ -529,242 +624,366 @@
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="35"/>
         <source>Disable uploads to server</source>
-        <translation type="unfinished">禁止上传到服务器</translation>
+        <translation>禁止上传到服务器</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="36"/>
         <source>Show LID column (requires restart)</source>
-        <translation type="unfinished">显示LID列（需要重启）</translation>
+        <translation>显示LID列（需要重启）</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="37"/>
         <source>Disable Tag Sorting (usefull for non-ASCII sort bug)</source>
-        <translation type="unfinished">禁用标签排序（用于非ASCII字符的排序bug）</translation>
+        <translation>禁用标签排序（对非ASCII字符的排序bug有用）</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="48"/>
         <source>Message Level</source>
-        <translation type="unfinished">消息等级</translation>
+        <translation>消息等级</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="51"/>
         <source>Trace</source>
         <translatorcomment>记录</translatorcomment>
-        <translation type="unfinished">Trace</translation>
+        <translation>Trace</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="52"/>
         <source>Debug</source>
         <translatorcomment>查错</translatorcomment>
-        <translation type="unfinished">Debug</translation>
+        <translation>Debug</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="53"/>
         <source>Info</source>
         <translatorcomment>信息</translatorcomment>
-        <translation type="unfinished">Info</translation>
+        <translation>Info</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="54"/>
         <source>Warnings</source>
         <translatorcomment>警告</translatorcomment>
-        <translation type="unfinished">Warnings</translation>
+        <translation>Warnings</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="55"/>
         <source>Errors</source>
         <translatorcomment>错误</translatorcomment>
-        <translation type="unfinished">Errors</translation>
+        <translation>Errors</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="56"/>
         <source>Fatal</source>
         <translatorcomment>致命错误</translatorcomment>
-        <translation type="unfinished">Fatal</translation>
+        <translation>Fatal</translation>
     </message>
 </context>
 <context>
     <name>EditorButtonBar</name>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="37"/>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="122"/>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="130"/>
         <source>Undo</source>
-        <translation type="unfinished">撤销</translation>
+        <translation>撤销</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="38"/>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="124"/>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="134"/>
         <source>Redo</source>
-        <translation type="unfinished">重做</translation>
+        <translation>重做</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="39"/>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="127"/>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="139"/>
         <source>Cut</source>
-        <translation type="unfinished">剪切</translation>
+        <translation>剪切</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="40"/>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="129"/>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="143"/>
         <source>Copy</source>
-        <translation type="unfinished">复制</translation>
+        <translation>复制</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="41"/>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="131"/>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="147"/>
         <source>Paste</source>
-        <translation type="unfinished">粘贴</translation>
+        <translation>粘贴</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="42"/>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="133"/>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="150"/>
         <source>Remove Formatting</source>
-        <translation type="unfinished">删除格式</translation>
+        <translation>删除格式</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="43"/>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="138"/>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="157"/>
         <source>Bold</source>
-        <translation type="unfinished">粗体</translation>
+        <translation>粗体</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="44"/>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="145"/>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="146"/>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="164"/>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="165"/>
         <source>Italics</source>
-        <translation type="unfinished">斜体</translation>
+        <translation>斜体</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="45"/>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="152"/>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="153"/>
-        <source>Underline</source>
-        <translation type="unfinished">下划线</translation>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="182"/>
+        <source>Superscript</source>
+        <translation>上标</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="46"/>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="157"/>
-        <source>Strikethrough</source>
-        <translation type="unfinished">删除线</translation>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="186"/>
+        <source>Subscript</source>
+        <translation>下标</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="47"/>
-        <source>Align Left</source>
-        <translation type="unfinished">居左对齐</translation>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="172"/>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="173"/>
+        <source>Underline</source>
+        <translation>下划线</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="48"/>
-        <source>Align Center</source>
-        <translation type="unfinished">居中对齐</translation>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="178"/>
+        <source>Strikethrough</source>
+        <translation>删除线</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="49"/>
-        <source>Align Right</source>
-        <translation type="unfinished">居右对齐</translation>
+        <source>Align Left</source>
+        <translation>居左对齐</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="50"/>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="167"/>
-        <source>Horizontal Line</source>
-        <translation type="unfinished">水平线</translation>
+        <source>Align Center</source>
+        <translation>居中对齐</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="51"/>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="170"/>
-        <source>Shift Right</source>
-        <translation type="unfinished">缩进</translation>
+        <source>Align Right</source>
+        <translation>居右对齐</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="52"/>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="172"/>
-        <source>Shift Left</source>
-        <translation type="unfinished">减少缩进</translation>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="202"/>
+        <source>Horizontal Line</source>
+        <translation>水平线</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="53"/>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="175"/>
-        <source>Bullet List</source>
-        <translation type="unfinished">项目列表</translation>
+        <source>Insert Date &amp;&amp; Time</source>
+        <translation>插入日期时间</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="54"/>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="177"/>
-        <source>Number List</source>
-        <translation type="unfinished">编号列表</translation>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="214"/>
+        <source>Shift Right</source>
+        <translation>缩进</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="55"/>
-        <source>Font</source>
-        <translation type="unfinished">字体</translation>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="218"/>
+        <source>Shift Left</source>
+        <translation>减少缩进</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="56"/>
-        <source>Font Size</source>
-        <translation type="unfinished">字号</translation>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="222"/>
+        <source>Bullet List</source>
+        <translation>项目列表</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="57"/>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="193"/>
-        <source>Font Color</source>
-        <translation type="unfinished">字体颜色</translation>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="226"/>
+        <source>Number List</source>
+        <translation>编号列表</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="58"/>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="202"/>
-        <source>Highlight</source>
-        <translation type="unfinished">高亮</translation>
+        <source>Font</source>
+        <translation>字体</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="59"/>
-        <source>To-do</source>
-        <translation type="unfinished">复选框</translation>
-    </message>
-    <message>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="205"/>
-        <source>Todo</source>
-        <translation type="unfinished">复选框</translation>
+        <source>Font Size</source>
+        <translation>字号</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="60"/>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="208"/>
-        <source>Spell Check</source>
-        <translation type="unfinished">拼写检查</translation>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="242"/>
+        <source>Font Color</source>
+        <translation>字体颜色</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="61"/>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="211"/>
-        <source>Insert Table</source>
-        <translation type="unfinished">插入表格</translation>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="251"/>
+        <source>Highlight</source>
+        <translation>高亮</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="62"/>
+        <source>To-do</source>
+        <translation>待办事项</translation>
+    </message>
+    <message>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="208"/>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="209"/>
+        <source>Insert Date &amp; Time</source>
+        <translation>插入日期时间</translation>
+    </message>
+    <message>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="256"/>
+        <source>Todo</source>
+        <translation>待办事项</translation>
+    </message>
+    <message>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="63"/>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="260"/>
+        <source>Spell Check</source>
+        <translation>拼写检查</translation>
+    </message>
+    <message>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="64"/>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="264"/>
+        <source>Insert Table</source>
+        <translation>插入表格</translation>
+    </message>
+    <message>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="65"/>
         <source>HTML Entities</source>
-        <translation type="unfinished">HTML实体</translation>
+        <translation>HTML实体</translation>
     </message>
     <message>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="160"/>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="198"/>
         <source>Left Justify</source>
-        <translation type="unfinished">左对齐</translation>
+        <translation>左对齐</translation>
     </message>
     <message>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="162"/>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="190"/>
         <source>Center</source>
-        <translation type="unfinished">居中</translation>
+        <translation>居中</translation>
     </message>
     <message>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="164"/>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="194"/>
         <source>Right Justify</source>
-        <translation type="unfinished">右对齐</translation>
+        <translation>右对齐</translation>
     </message>
     <message>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="214"/>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="268"/>
         <source>Insert HTML Entities</source>
-        <translation type="unfinished">插入HTML实体</translation>
+        <translation>插入HTML实体</translation>
     </message>
     <message>
-        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="533"/>
+        <location filename="../gui/browserWidgets/editorbuttonbar.cpp" line="644"/>
         <source>Times</source>
         <translation type="unfinished">Times</translation>
+    </message>
+</context>
+<context>
+    <name>EmailDialog</name>
+    <message>
+        <location filename="../dialog/emaildialog.cpp" line="36"/>
+        <source>Send Email</source>
+        <translation>发送邮件</translation>
+    </message>
+    <message>
+        <location filename="../dialog/emaildialog.cpp" line="38"/>
+        <source>Send</source>
+        <translation>发送</translation>
+    </message>
+    <message>
+        <location filename="../dialog/emaildialog.cpp" line="39"/>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <location filename="../dialog/emaildialog.cpp" line="51"/>
+        <source>To:</source>
+        <translation>发送到：</translation>
+    </message>
+    <message>
+        <location filename="../dialog/emaildialog.cpp" line="53"/>
+        <source>BCC:</source>
+        <translation>密送：</translation>
+    </message>
+    <message>
+        <location filename="../dialog/emaildialog.cpp" line="55"/>
+        <source>CC:</source>
+        <translation>抄送：</translation>
+    </message>
+    <message>
+        <location filename="../dialog/emaildialog.cpp" line="57"/>
+        <source>Subject:</source>
+        <translation>主题：</translation>
+    </message>
+    <message>
+        <location filename="../dialog/emaildialog.cpp" line="59"/>
+        <source>Note:</source>
+        <translation>笔记：</translation>
+    </message>
+    <message>
+        <location filename="../dialog/emaildialog.cpp" line="77"/>
+        <source>CC me on this email</source>
+        <translation type="unfinished">抄送给自己</translation>
+    </message>
+</context>
+<context>
+    <name>EmailPreferences</name>
+    <message>
+        <location filename="../dialog/preferences/emailpreferences.cpp" line="10"/>
+        <source>SMTP Server</source>
+        <translation>SMTP服务器</translation>
+    </message>
+    <message>
+        <location filename="../dialog/preferences/emailpreferences.cpp" line="11"/>
+        <source>Server Port</source>
+        <translation>服务器端口</translation>
+    </message>
+    <message>
+        <location filename="../dialog/preferences/emailpreferences.cpp" line="12"/>
+        <source>Userid</source>
+        <translation type="unfinished">用户id</translation>
+    </message>
+    <message>
+        <location filename="../dialog/preferences/emailpreferences.cpp" line="13"/>
+        <source>Password</source>
+        <translation>密码</translation>
+    </message>
+    <message>
+        <location filename="../dialog/preferences/emailpreferences.cpp" line="14"/>
+        <source>Sender Display Name</source>
+        <translation>发送者姓名</translation>
+    </message>
+    <message>
+        <location filename="../dialog/preferences/emailpreferences.cpp" line="15"/>
+        <source>Sender Email</source>
+        <translation>发送者邮箱</translation>
+    </message>
+    <message>
+        <location filename="../dialog/preferences/emailpreferences.cpp" line="16"/>
+        <source>Connection Type</source>
+        <translation>连接类型</translation>
+    </message>
+    <message>
+        <location filename="../dialog/preferences/emailpreferences.cpp" line="24"/>
+        <source>Plain Text</source>
+        <translation>明文</translation>
+    </message>
+    <message>
+        <location filename="../dialog/preferences/emailpreferences.cpp" line="25"/>
+        <source>SSL Connection</source>
+        <translation>SSL加密</translation>
+    </message>
+    <message>
+        <location filename="../dialog/preferences/emailpreferences.cpp" line="26"/>
+        <source>TLS Connection</source>
+        <translation>TLS加密</translation>
     </message>
 </context>
 <context>
@@ -772,52 +991,52 @@
     <message>
         <location filename="../dialog/encryptdialog.cpp" line="31"/>
         <source>Encrypt Text</source>
-        <translation type="unfinished">加密文本</translation>
+        <translation>加密文本</translation>
     </message>
     <message>
         <location filename="../dialog/encryptdialog.cpp" line="47"/>
         <source>Password</source>
-        <translation type="unfinished">密码</translation>
+        <translation>密码</translation>
     </message>
     <message>
         <location filename="../dialog/encryptdialog.cpp" line="49"/>
         <source>Verify</source>
-        <translation type="unfinished">确认密码</translation>
+        <translation>确认密码</translation>
     </message>
     <message>
         <location filename="../dialog/encryptdialog.cpp" line="51"/>
         <source>Hint</source>
-        <translation type="unfinished">密码提示</translation>
+        <translation>密码提示</translation>
     </message>
     <message>
         <location filename="../dialog/encryptdialog.cpp" line="53"/>
         <source>Remember Password</source>
-        <translation type="unfinished">记住密码</translation>
+        <translation>记住密码</translation>
     </message>
     <message>
         <location filename="../dialog/encryptdialog.cpp" line="61"/>
         <source>OK</source>
-        <translation type="unfinished">确定</translation>
+        <translation>确定</translation>
     </message>
     <message>
         <location filename="../dialog/encryptdialog.cpp" line="65"/>
         <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
+        <translation>取消</translation>
     </message>
     <message>
         <location filename="../dialog/encryptdialog.cpp" line="113"/>
         <source>Password must be at least 4 characters</source>
-        <translation type="unfinished">密码长度必须至少4个字符</translation>
+        <translation>密码长度必须至少4个字符</translation>
     </message>
     <message>
         <location filename="../dialog/encryptdialog.cpp" line="117"/>
         <source>Passwords do not match</source>
-        <translation type="unfinished">密码不匹配</translation>
+        <translation>密码不匹配</translation>
     </message>
     <message>
         <location filename="../dialog/encryptdialog.cpp" line="121"/>
         <source>Hint must be entered</source>
-        <translation type="unfinished">必须输入密码提示</translation>
+        <translation>必须输入密码提示</translation>
     </message>
 </context>
 <context>
@@ -825,37 +1044,37 @@
     <message>
         <location filename="../dialog/endecryptdialog.cpp" line="35"/>
         <source>Decrypt</source>
-        <translation type="unfinished">解密</translation>
+        <translation>解密</translation>
     </message>
     <message>
         <location filename="../dialog/endecryptdialog.cpp" line="51"/>
         <source>Password</source>
-        <translation type="unfinished">密码</translation>
+        <translation>密码</translation>
     </message>
     <message>
         <location filename="../dialog/endecryptdialog.cpp" line="52"/>
         <source>Hint</source>
-        <translation type="unfinished">密码提示</translation>
+        <translation>密码提示</translation>
     </message>
     <message>
         <location filename="../dialog/endecryptdialog.cpp" line="59"/>
         <source>Permanently Decrypt</source>
-        <translation type="unfinished">永久解密</translation>
+        <translation>永久解密</translation>
     </message>
     <message>
         <location filename="../dialog/endecryptdialog.cpp" line="61"/>
         <source>Remember Password</source>
-        <translation type="unfinished">记住密码</translation>
+        <translation>记住密码</translation>
     </message>
     <message>
         <location filename="../dialog/endecryptdialog.cpp" line="66"/>
         <source>OK</source>
-        <translation type="unfinished">确定</translation>
+        <translation>确定</translation>
     </message>
     <message>
         <location filename="../dialog/endecryptdialog.cpp" line="70"/>
         <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
+        <translation>取消</translation>
     </message>
 </context>
 <context>
@@ -863,52 +1082,52 @@
     <message>
         <location filename="../xml/exportdata.cpp" line="53"/>
         <source>Cannot open file.</source>
-        <translation type="unfinished">无法打开文件。</translation>
+        <translation>无法打开文件。</translation>
     </message>
     <message>
         <location filename="../xml/exportdata.cpp" line="60"/>
         <source>Export</source>
-        <translation type="unfinished">导出</translation>
+        <translation>导出</translation>
     </message>
     <message>
         <location filename="../xml/exportdata.cpp" line="77"/>
         <source>Backup</source>
-        <translation type="unfinished">备份</translation>
+        <translation>备份</translation>
     </message>
     <message>
-        <location filename="../xml/exportdata.cpp" line="106"/>
+        <location filename="../xml/exportdata.cpp" line="108"/>
         <source>Tags</source>
-        <translation type="unfinished">标签</translation>
+        <translation>标签</translation>
     </message>
     <message>
-        <location filename="../xml/exportdata.cpp" line="140"/>
+        <location filename="../xml/exportdata.cpp" line="142"/>
         <source>Notebooks</source>
-        <translation type="unfinished">笔记本</translation>
+        <translation>笔记本</translation>
     </message>
     <message>
-        <location filename="../xml/exportdata.cpp" line="346"/>
+        <location filename="../xml/exportdata.cpp" line="348"/>
         <source>Searches</source>
         <translation type="unfinished">搜索内容</translation>
     </message>
     <message>
-        <location filename="../xml/exportdata.cpp" line="388"/>
+        <location filename="../xml/exportdata.cpp" line="390"/>
         <source>Linked Notebooks</source>
         <translation type="unfinished">已链接笔记本</translation>
     </message>
     <message>
-        <location filename="../xml/exportdata.cpp" line="428"/>
+        <location filename="../xml/exportdata.cpp" line="430"/>
         <source>Shared Notebooks</source>
         <translation type="unfinished">已共享笔记本</translation>
     </message>
     <message>
-        <location filename="../xml/exportdata.cpp" line="480"/>
+        <location filename="../xml/exportdata.cpp" line="487"/>
         <source>Notes</source>
-        <translation type="unfinished">笔记</translation>
+        <translation>笔记</translation>
     </message>
     <message>
-        <location filename="../xml/exportdata.cpp" line="708"/>
+        <location filename="../xml/exportdata.cpp" line="702"/>
         <source>Backup Canceled</source>
-        <translation type="unfinished">备份已取消</translation>
+        <translation>备份已取消</translation>
     </message>
 </context>
 <context>
@@ -916,35 +1135,35 @@
     <message>
         <location filename="../gui/externalbrowse.cpp" line="32"/>
         <source>NixNote</source>
-        <translation type="unfinished">NixNote</translation>
+        <translation>NixNote</translation>
     </message>
     <message>
         <location filename="../gui/externalbrowse.cpp" line="85"/>
         <source>NixNote - </source>
-        <translation type="unfinished">NixNote - </translation>
+        <translation>NixNote - </translation>
     </message>
 </context>
 <context>
     <name>FavoritesView</name>
     <message>
-        <location filename="../gui/favoritesview.cpp" line="66"/>
+        <location filename="../gui/favoritesview.cpp" line="67"/>
         <source>Shortcuts</source>
-        <translation type="unfinished">快捷方式</translation>
+        <translation>快捷方式</translation>
     </message>
     <message>
-        <location filename="../gui/favoritesview.cpp" line="88"/>
+        <location filename="../gui/favoritesview.cpp" line="89"/>
         <source>Remove from shortcuts</source>
-        <translation type="unfinished">从快捷方式里删除</translation>
-    </message>
-    <message>
-        <location filename="../gui/favoritesview.cpp" line="557"/>
-        <source>Are you sure you want to remove this favorite?</source>
-        <translation type="unfinished">确定要删除这个收藏？</translation>
+        <translation>从快捷方式里删除</translation>
     </message>
     <message>
         <location filename="../gui/favoritesview.cpp" line="558"/>
+        <source>Are you sure you want to remove this favorite?</source>
+        <translation>确定要删除这个收藏？</translation>
+    </message>
+    <message>
+        <location filename="../gui/favoritesview.cpp" line="559"/>
         <source>Verify Delete</source>
-        <translation type="unfinished">删除确认</translation>
+        <translation>删除确认</translation>
     </message>
 </context>
 <context>
@@ -952,27 +1171,27 @@
     <message>
         <location filename="../gui/findreplace.cpp" line="46"/>
         <source>Next</source>
-        <translation type="unfinished">下一个</translation>
+        <translation>下一个</translation>
     </message>
     <message>
         <location filename="../gui/findreplace.cpp" line="47"/>
         <source>Previous</source>
-        <translation type="unfinished">上一个</translation>
+        <translation>上一个</translation>
     </message>
     <message>
         <location filename="../gui/findreplace.cpp" line="48"/>
         <source>Match case</source>
-        <translation type="unfinished">匹配大小写</translation>
+        <translation>匹配大小写</translation>
     </message>
     <message>
         <location filename="../gui/findreplace.cpp" line="57"/>
         <source>Replace</source>
-        <translation type="unfinished">替换</translation>
+        <translation>替换</translation>
     </message>
     <message>
         <location filename="../gui/findreplace.cpp" line="58"/>
         <source>Replace all</source>
-        <translation type="unfinished">全部替换</translation>
+        <translation>全部替换</translation>
     </message>
 </context>
 <context>
@@ -980,33 +1199,33 @@
     <message>
         <location filename="../dialog/htmlentitiesdialog.cpp" line="33"/>
         <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
+        <translation>取消</translation>
     </message>
     <message>
         <location filename="../dialog/htmlentitiesdialog.cpp" line="34"/>
         <source>Close</source>
-        <translation type="unfinished">关闭</translation>
+        <translation>关闭</translation>
     </message>
     <message>
         <location filename="../dialog/htmlentitiesdialog.cpp" line="35"/>
         <source>Edit entries list</source>
-        <translation type="unfinished">编辑实体列表</translation>
+        <translation>编辑实体列表</translation>
     </message>
     <message>
         <location filename="../dialog/htmlentitiesdialog.cpp" line="36"/>
         <source>Save entities list</source>
-        <translation type="unfinished">保存实体列表</translation>
+        <translation>保存实体列表</translation>
     </message>
     <message>
         <location filename="../dialog/htmlentitiesdialog.cpp" line="71"/>
         <source>HTML Entities Selection</source>
-        <translation type="unfinished">选择HTML实体</translation>
+        <translation>选择HTML实体</translation>
     </message>
     <message>
         <location filename="../dialog/htmlentitiesdialog.cpp" line="206"/>
         <source>Comma separated list of HTML entities.
 See http://www.w3schools.com/charsets/ for list.</source>
-        <translation type="unfinished">HTML实体列表通过逗号分隔。
+        <translation>HTML实体列表通过逗号分隔。
 详细列表请看 http://www.w3schools.com/charsets 。</translation>
     </message>
 </context>
@@ -1015,38 +1234,38 @@ See http://www.w3schools.com/charsets/ for list.</source>
     <message>
         <location filename="../xml/importdata.cpp" line="58"/>
         <source>Imported Notes</source>
-        <translation type="unfinished">已导入笔记</translation>
+        <translation>已导入笔记</translation>
     </message>
     <message>
         <location filename="../xml/importdata.cpp" line="101"/>
         <source>Scanning File</source>
-        <translation type="unfinished">扫描文件</translation>
+        <translation>扫描文件</translation>
     </message>
     <message>
         <location filename="../xml/importdata.cpp" line="102"/>
         <location filename="../xml/importdata.cpp" line="112"/>
         <source> notes found.</source>
-        <translation type="unfinished">篇笔记已找到。</translation>
+        <translation>篇笔记已找到。</translation>
     </message>
     <message>
         <location filename="../xml/importdata.cpp" line="121"/>
         <source>Importing</source>
-        <translation type="unfinished">正在导入</translation>
+        <translation>正在导入</translation>
     </message>
     <message>
         <location filename="../xml/importdata.cpp" line="122"/>
         <source>Importing Notes</source>
-        <translation type="unfinished">正在导入笔记</translation>
+        <translation>正在导入笔记</translation>
     </message>
     <message>
         <location filename="../xml/importdata.cpp" line="124"/>
         <source>Restore</source>
-        <translation type="unfinished">恢复</translation>
+        <translation>恢复</translation>
     </message>
     <message>
         <location filename="../xml/importdata.cpp" line="125"/>
         <source>Restoring Notes</source>
-        <translation type="unfinished">正在恢复笔记</translation>
+        <translation>正在恢复笔记</translation>
     </message>
 </context>
 <context>
@@ -1054,24 +1273,24 @@ See http://www.w3schools.com/charsets/ for list.</source>
     <message>
         <location filename="../xml/importenex.cpp" line="40"/>
         <source>Imported Notes</source>
-        <translation type="unfinished">已导入笔记</translation>
+        <translation>已导入笔记</translation>
     </message>
     <message>
         <location filename="../xml/importenex.cpp" line="83"/>
         <source>Scanning File</source>
-        <translation type="unfinished">扫描文件</translation>
+        <translation>扫描文件</translation>
     </message>
     <message>
         <location filename="../xml/importenex.cpp" line="84"/>
         <location filename="../xml/importenex.cpp" line="94"/>
         <source> notes found.</source>
-        <translation type="unfinished">篇笔记已找到。</translation>
+        <translation>篇笔记已找到。</translation>
     </message>
     <message>
         <location filename="../xml/importenex.cpp" line="101"/>
         <location filename="../xml/importenex.cpp" line="102"/>
         <source>Importing Notes</source>
-        <translation type="unfinished">正在导入笔记</translation>
+        <translation>正在导入笔记</translation>
     </message>
 </context>
 <context>
@@ -1079,22 +1298,22 @@ See http://www.w3schools.com/charsets/ for list.</source>
     <message>
         <location filename="../dialog/insertlatexdialog.cpp" line="32"/>
         <source>Insert LaTeX Formula</source>
-        <translation type="unfinished">插入LaTeX公式</translation>
+        <translation>插入LaTeX公式</translation>
     </message>
     <message>
         <location filename="../dialog/insertlatexdialog.cpp" line="42"/>
         <source>Formula</source>
-        <translation type="unfinished">公式</translation>
+        <translation>公式</translation>
     </message>
     <message>
         <location filename="../dialog/insertlatexdialog.cpp" line="47"/>
         <source>OK</source>
-        <translation type="unfinished">确定</translation>
+        <translation>确定</translation>
     </message>
     <message>
-        <location filename="../dialog/insertlatexdialog.cpp" line="51"/>
+        <location filename="../dialog/insertlatexdialog.cpp" line="52"/>
         <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
+        <translation>取消</translation>
     </message>
 </context>
 <context>
@@ -1102,22 +1321,22 @@ See http://www.w3schools.com/charsets/ for list.</source>
     <message>
         <location filename="../dialog/insertlinkdialog.cpp" line="34"/>
         <source>Insert Link</source>
-        <translation type="unfinished">插入链接</translation>
+        <translation>插入链接</translation>
     </message>
     <message>
         <location filename="../dialog/insertlinkdialog.cpp" line="45"/>
         <source>URL</source>
-        <translation type="unfinished">URL</translation>
+        <translation>URL</translation>
     </message>
     <message>
         <location filename="../dialog/insertlinkdialog.cpp" line="50"/>
         <source>OK</source>
-        <translation type="unfinished">确定</translation>
+        <translation>确定</translation>
     </message>
     <message>
         <location filename="../dialog/insertlinkdialog.cpp" line="54"/>
         <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
+        <translation>取消</translation>
     </message>
 </context>
 <context>
@@ -1125,7 +1344,7 @@ See http://www.w3schools.com/charsets/ for list.</source>
     <message>
         <location filename="../gui/lineedit.cpp" line="39"/>
         <source>Search</source>
-        <translation type="unfinished">搜索</translation>
+        <translation>搜索</translation>
     </message>
 </context>
 <context>
@@ -1133,112 +1352,112 @@ See http://www.w3schools.com/charsets/ for list.</source>
     <message>
         <location filename="../dialog/preferences/localepreferences.cpp" line="37"/>
         <source>Date Format</source>
-        <translation type="unfinished">日期格式</translation>
+        <translation>日期格式</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/localepreferences.cpp" line="40"/>
         <source>MM/dd/yy - </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialog/preferences/localepreferences.cpp" line="41"/>
         <source>MM/dd/yyyy - </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialog/preferences/localepreferences.cpp" line="42"/>
         <source>M/dd/yyyy - </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialog/preferences/localepreferences.cpp" line="43"/>
         <source>M/d/yyyy - </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialog/preferences/localepreferences.cpp" line="44"/>
         <source>dd/MM/yy - </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialog/preferences/localepreferences.cpp" line="45"/>
         <source>d/M/yy - </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialog/preferences/localepreferences.cpp" line="46"/>
         <source>dd/MM/yyyy - </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialog/preferences/localepreferences.cpp" line="47"/>
         <source>d/M/yyyy - </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialog/preferences/localepreferences.cpp" line="48"/>
         <source>yyyy-MM-dd - </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialog/preferences/localepreferences.cpp" line="49"/>
         <source>yy-MM-dd - </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialog/preferences/localepreferences.cpp" line="52"/>
         <source>Time Format</source>
-        <translation type="unfinished">时间格式</translation>
+        <translation>时间格式</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/localepreferences.cpp" line="55"/>
         <source>HH:mm:ss - </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialog/preferences/localepreferences.cpp" line="56"/>
         <source>HH:mm:ss a - </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialog/preferences/localepreferences.cpp" line="57"/>
         <source>HH:mm - </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialog/preferences/localepreferences.cpp" line="58"/>
         <source>HH:mm a - </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialog/preferences/localepreferences.cpp" line="59"/>
         <source>hh:mm:ss - </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialog/preferences/localepreferences.cpp" line="60"/>
         <source>hh:mm:ss a- </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialog/preferences/localepreferences.cpp" line="61"/>
         <source>h:mm:ss a - </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialog/preferences/localepreferences.cpp" line="62"/>
         <source>hh:mm - </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialog/preferences/localepreferences.cpp" line="63"/>
         <source>hh:mm a - </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialog/preferences/localepreferences.cpp" line="64"/>
         <source>h:mm a - </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -1246,32 +1465,32 @@ See http://www.w3schools.com/charsets/ for list.</source>
     <message>
         <location filename="../dialog/locationdialog.cpp" line="33"/>
         <source>Location</source>
-        <translation type="unfinished">位置</translation>
+        <translation>位置</translation>
     </message>
     <message>
         <location filename="../dialog/locationdialog.cpp" line="40"/>
         <source>Longitude</source>
-        <translation type="unfinished">经度</translation>
+        <translation>经度</translation>
     </message>
     <message>
         <location filename="../dialog/locationdialog.cpp" line="42"/>
         <source>Latitude</source>
-        <translation type="unfinished">纬度</translation>
+        <translation>纬度</translation>
     </message>
     <message>
         <location filename="../dialog/locationdialog.cpp" line="44"/>
         <source>Altitude</source>
-        <translation type="unfinished">海拔</translation>
+        <translation>海拔</translation>
     </message>
     <message>
         <location filename="../dialog/locationdialog.cpp" line="49"/>
         <source>OK</source>
-        <translation type="unfinished">确定</translation>
+        <translation>确定</translation>
     </message>
     <message>
         <location filename="../dialog/locationdialog.cpp" line="52"/>
         <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
+        <translation>取消</translation>
     </message>
 </context>
 <context>
@@ -1279,22 +1498,22 @@ See http://www.w3schools.com/charsets/ for list.</source>
     <message>
         <location filename="../gui/browserWidgets/locationeditor.cpp" line="42"/>
         <source>Click to set location...</source>
-        <translation type="unfinished">点击设置位置...</translation>
+        <translation>点击设置位置...</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/locationeditor.cpp" line="45"/>
         <source>Edit...</source>
-        <translation type="unfinished">编辑...</translation>
+        <translation>编辑...</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/locationeditor.cpp" line="46"/>
         <source>Clear</source>
-        <translation type="unfinished">清除</translation>
+        <translation>清除</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/locationeditor.cpp" line="47"/>
         <source>View on map</source>
-        <translation type="unfinished">在地图中查看</translation>
+        <translation>在地图中查看</translation>
     </message>
 </context>
 <context>
@@ -1302,32 +1521,32 @@ See http://www.w3schools.com/charsets/ for list.</source>
     <message>
         <location filename="../dialog/logviewer.cpp" line="41"/>
         <source>Close</source>
-        <translation type="unfinished">关闭</translation>
+        <translation>关闭</translation>
     </message>
     <message>
         <location filename="../dialog/logviewer.cpp" line="43"/>
         <source>Refresh</source>
-        <translation type="unfinished">刷新</translation>
+        <translation>刷新</translation>
     </message>
     <message>
         <location filename="../dialog/logviewer.cpp" line="45"/>
         <source>Save</source>
-        <translation type="unfinished">保存</translation>
+        <translation>保存</translation>
     </message>
     <message>
         <location filename="../dialog/logviewer.cpp" line="54"/>
         <source>Save Logs</source>
-        <translation type="unfinished">保存日志</translation>
+        <translation>保存日志</translation>
     </message>
     <message>
-        <location filename="../dialog/logviewer.cpp" line="85"/>
+        <location filename="../dialog/logviewer.cpp" line="83"/>
         <source>Save Log</source>
-        <translation type="unfinished">保存日志</translation>
+        <translation>保存日志</translation>
     </message>
     <message>
-        <location filename="../dialog/logviewer.cpp" line="86"/>
+        <location filename="../dialog/logviewer.cpp" line="83"/>
         <source>NixNote Log (*.log);;All Files (*.*)</source>
-        <translation type="unfinished">NixNote日志(*.log);;所有文件(*.*)</translation>
+        <translation>NixNote日志(*.log);;所有文件(*.*)</translation>
     </message>
 </context>
 <context>
@@ -1335,27 +1554,27 @@ See http://www.w3schools.com/charsets/ for list.</source>
     <message>
         <location filename="../dialog/logindialog.cpp" line="34"/>
         <source>NixNote Login</source>
-        <translation type="unfinished">NixNote登录</translation>
+        <translation>NixNote登录</translation>
     </message>
     <message>
         <location filename="../dialog/logindialog.cpp" line="43"/>
         <source>Userid</source>
-        <translation type="unfinished">用户id</translation>
+        <translation>用户id</translation>
     </message>
     <message>
         <location filename="../dialog/logindialog.cpp" line="44"/>
         <source>Password</source>
-        <translation type="unfinished">密码</translation>
+        <translation>密码</translation>
     </message>
     <message>
         <location filename="../dialog/logindialog.cpp" line="52"/>
         <source>OK</source>
-        <translation type="unfinished">确定</translation>
+        <translation>确定</translation>
     </message>
     <message>
         <location filename="../dialog/logindialog.cpp" line="56"/>
         <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
+        <translation>取消</translation>
     </message>
 </context>
 <context>
@@ -1363,18 +1582,18 @@ See http://www.w3schools.com/charsets/ for list.</source>
     <message>
         <location filename="../gui/nattributetree.cpp" line="48"/>
         <source>Attributes</source>
-        <translation type="unfinished">属性</translation>
+        <translation>属性</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="125"/>
         <source>Created</source>
-        <translation type="unfinished">创建时间</translation>
+        <translation>创建时间</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="128"/>
         <location filename="../gui/nattributetree.cpp" line="209"/>
         <source>Since</source>
-        <translation type="unfinished">从</translation>
+        <translation type="unfinished">...以来</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="132"/>
@@ -1382,7 +1601,7 @@ See http://www.w3schools.com/charsets/ for list.</source>
         <location filename="../gui/nattributetree.cpp" line="213"/>
         <location filename="../gui/nattributetree.cpp" line="250"/>
         <source>Today</source>
-        <translation type="unfinished">今天</translation>
+        <translation>今天</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="136"/>
@@ -1390,7 +1609,7 @@ See http://www.w3schools.com/charsets/ for list.</source>
         <location filename="../gui/nattributetree.cpp" line="217"/>
         <location filename="../gui/nattributetree.cpp" line="254"/>
         <source>Yesterday</source>
-        <translation type="unfinished">昨天</translation>
+        <translation>昨天</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="140"/>
@@ -1398,7 +1617,7 @@ See http://www.w3schools.com/charsets/ for list.</source>
         <location filename="../gui/nattributetree.cpp" line="221"/>
         <location filename="../gui/nattributetree.cpp" line="258"/>
         <source>This week</source>
-        <translation type="unfinished">本周</translation>
+        <translation>本周</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="144"/>
@@ -1406,7 +1625,7 @@ See http://www.w3schools.com/charsets/ for list.</source>
         <location filename="../gui/nattributetree.cpp" line="225"/>
         <location filename="../gui/nattributetree.cpp" line="262"/>
         <source>Last week</source>
-        <translation type="unfinished">上周</translation>
+        <translation>上周</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="148"/>
@@ -1414,7 +1633,7 @@ See http://www.w3schools.com/charsets/ for list.</source>
         <location filename="../gui/nattributetree.cpp" line="229"/>
         <location filename="../gui/nattributetree.cpp" line="266"/>
         <source>This Month</source>
-        <translation type="unfinished">本月</translation>
+        <translation>本月</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="152"/>
@@ -1422,7 +1641,7 @@ See http://www.w3schools.com/charsets/ for list.</source>
         <location filename="../gui/nattributetree.cpp" line="233"/>
         <location filename="../gui/nattributetree.cpp" line="270"/>
         <source>Last Month</source>
-        <translation type="unfinished">上月</translation>
+        <translation>上月</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="156"/>
@@ -1430,7 +1649,7 @@ See http://www.w3schools.com/charsets/ for list.</source>
         <location filename="../gui/nattributetree.cpp" line="237"/>
         <location filename="../gui/nattributetree.cpp" line="274"/>
         <source>This Year</source>
-        <translation type="unfinished">今年</translation>
+        <translation>今年</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="160"/>
@@ -1438,1133 +1657,1201 @@ See http://www.w3schools.com/charsets/ for list.</source>
         <location filename="../gui/nattributetree.cpp" line="241"/>
         <location filename="../gui/nattributetree.cpp" line="278"/>
         <source>Last Year</source>
-        <translation type="unfinished">去年</translation>
+        <translation>去年</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="165"/>
         <location filename="../gui/nattributetree.cpp" line="246"/>
         <source>Before</source>
-        <translation type="unfinished">之前</translation>
+        <translation type="unfinished">...之前</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="206"/>
         <source>Last Modified</source>
-        <translation type="unfinished">最后修改</translation>
+        <translation>最后修改</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="285"/>
         <source>Contains</source>
-        <translation type="unfinished">内容</translation>
+        <translation>内容</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="288"/>
         <source>Images</source>
-        <translation type="unfinished">图像</translation>
+        <translation>图像</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="292"/>
         <source>Audio</source>
-        <translation type="unfinished">音频</translation>
+        <translation>音频</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="296"/>
         <source>Ink</source>
-        <translation type="unfinished">手写笔记</translation>
+        <translation>手写笔记</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="300"/>
         <source>Encrypted Text</source>
-        <translation type="unfinished">加密文本</translation>
+        <translation>加密文本</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="304"/>
         <source>To-do items</source>
-        <translation type="unfinished">待办项目</translation>
+        <translation>待办事项</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="308"/>
         <source>Unfinished to-do items</source>
-        <translation type="unfinished">未完成的待办项目</translation>
+        <translation>未完成的待办事项</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="312"/>
         <source>Finished to-do items</source>
-        <translation type="unfinished">已完成的待办项目</translation>
+        <translation>已完成的待办事项</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="316"/>
         <source>PDF document</source>
-        <translation type="unfinished">PDF文档</translation>
+        <translation>PDF文档</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="320"/>
         <source>Attachment</source>
-        <translation type="unfinished">附件</translation>
+        <translation>附件</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="327"/>
         <source>Source</source>
-        <translation type="unfinished">来源</translation>
+        <translation>来源</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="330"/>
         <source>Emailed to Evernote</source>
-        <translation type="unfinished">邮件发送到Evernote</translation>
+        <translation>邮件发送到Evernote</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="334"/>
         <source>Email</source>
-        <translation type="unfinished">邮箱</translation>
+        <translation>邮箱</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="338"/>
         <source>Web page</source>
-        <translation type="unfinished">网页</translation>
+        <translation>网页</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="342"/>
         <source>Mobile</source>
-        <translation type="unfinished">移动版</translation>
+        <translation>移动版</translation>
     </message>
     <message>
         <location filename="../gui/nattributetree.cpp" line="346"/>
         <source>Another application</source>
-        <translation type="unfinished">其他应用</translation>
+        <translation>其他应用</translation>
     </message>
 </context>
 <context>
     <name>NBrowserWindow</name>
     <message>
-        <location filename="../gui/nbrowserwindow.cpp" line="509"/>
-        <location filename="../gui/nbrowserwindow.cpp" line="2624"/>
+        <location filename="../gui/nbrowserwindow.cpp" line="484"/>
+        <location filename="../gui/nbrowserwindow.cpp" line="2918"/>
         <source>Today</source>
-        <translation type="unfinished">今天</translation>
+        <translation>今天</translation>
     </message>
     <message>
-        <location filename="../gui/nbrowserwindow.cpp" line="511"/>
-        <location filename="../gui/nbrowserwindow.cpp" line="2626"/>
+        <location filename="../gui/nbrowserwindow.cpp" line="486"/>
+        <location filename="../gui/nbrowserwindow.cpp" line="2920"/>
         <source>Tomorrow</source>
-        <translation type="unfinished">明天</translation>
+        <translation>明天</translation>
     </message>
     <message>
-        <location filename="../gui/nbrowserwindow.cpp" line="513"/>
-        <location filename="../gui/nbrowserwindow.cpp" line="2628"/>
+        <location filename="../gui/nbrowserwindow.cpp" line="488"/>
+        <location filename="../gui/nbrowserwindow.cpp" line="2922"/>
         <source>Yesterday</source>
-        <translation type="unfinished">昨天</translation>
+        <translation>昨天</translation>
     </message>
     <message>
-        <location filename="../gui/nbrowserwindow.cpp" line="776"/>
+        <location filename="../gui/nbrowserwindow.cpp" line="751"/>
         <source>Unable to Save</source>
-        <translation type="unfinished">无法保存</translation>
+        <translation>无法保存</translation>
     </message>
     <message>
-        <location filename="../gui/nbrowserwindow.cpp" line="776"/>
+        <location filename="../gui/nbrowserwindow.cpp" line="751"/>
         <source>Unable to save this note.  Either tidy isn&apos;t installed or the note is too complex to save.</source>
-        <translation type="unfinished">无法保存笔记。Tidy未安装或者笔记格式太复杂。</translation>
+        <translation>无法保存笔记。Tidy未安装或者笔记格式太复杂。</translation>
     </message>
     <message>
-        <location filename="../gui/nbrowserwindow.cpp" line="1646"/>
+        <location filename="../gui/nbrowserwindow.cpp" line="1660"/>
         <source>Insert Link</source>
-        <translation type="unfinished">插入链接</translation>
+        <translation>插入链接</translation>
     </message>
     <message>
-        <location filename="../gui/nbrowserwindow.cpp" line="1872"/>
+        <location filename="../gui/nbrowserwindow.cpp" line="1901"/>
         <source>Unable Open</source>
-        <translation type="unfinished">无法打开</translation>
+        <translation>无法打开</translation>
     </message>
     <message>
-        <location filename="../gui/nbrowserwindow.cpp" line="1872"/>
+        <location filename="../gui/nbrowserwindow.cpp" line="1901"/>
         <source>This is an ink note.
 Ink notes are not supported since Evernote has not
  published any specifications on them
 and I&apos;m too lazy to figure them out by myself.</source>
-        <translation type="unfinished">这是一个手写笔记。
+        <translation>这是一个手写笔记。
 由于Evernote未公布任何手写笔记的技术细节
 而作者本人又懒于自己去找，所以手写笔记不被支持。</translation>
     </message>
     <message>
-        <location filename="../gui/nbrowserwindow.cpp" line="2035"/>
+        <location filename="../gui/nbrowserwindow.cpp" line="2065"/>
         <source>Edit Link</source>
-        <translation type="unfinished">编辑链接</translation>
+        <translation>编辑链接</translation>
     </message>
     <message>
-        <location filename="../gui/nbrowserwindow.cpp" line="2100"/>
+        <location filename="../gui/nbrowserwindow.cpp" line="2128"/>
         <source>Unable to create LaTeX image</source>
-        <translation type="unfinished">无法创建LaTeX图像</translation>
+        <translation>无法创建LaTeX图像</translation>
     </message>
     <message>
-        <location filename="../gui/nbrowserwindow.cpp" line="2101"/>
+        <location filename="../gui/nbrowserwindow.cpp" line="2129"/>
         <source>Unable to create LaTeX image.  Are you sure mimetex is installed?</source>
-        <translation type="unfinished">无法创建LaTeX图像。请确定mimetex已安装。</translation>
+        <translation>无法创建LaTeX图像。请确定mimetex已安装。</translation>
     </message>
     <message>
-        <location filename="../gui/nbrowserwindow.cpp" line="2340"/>
+        <location filename="../gui/nbrowserwindow.cpp" line="2454"/>
+        <source>Setup Error</source>
+        <translation>配置错误</translation>
+    </message>
+    <message>
+        <location filename="../gui/nbrowserwindow.cpp" line="2455"/>
+        <source>SMTP Server has not been setup.
+
+Please specify server settings
+in the Preferences menu.</source>
+        <translation>未配置SMTP服务器。
+
+请在选项菜单中指定服务器配置。</translation>
+    </message>
+    <message>
+        <location filename="../gui/nbrowserwindow.cpp" line="2523"/>
+        <source>Connection Error</source>
+        <translation>连接错误</translation>
+    </message>
+    <message>
+        <location filename="../gui/nbrowserwindow.cpp" line="2523"/>
+        <source>Unable to connect to host.</source>
+        <translation>无法连接到主机。</translation>
+    </message>
+    <message>
+        <location filename="../gui/nbrowserwindow.cpp" line="2529"/>
+        <source>Login Error</source>
+        <translation>登录错误</translation>
+    </message>
+    <message>
+        <location filename="../gui/nbrowserwindow.cpp" line="2529"/>
+        <source>Unable to login.</source>
+        <translation>无法登录。</translation>
+    </message>
+    <message>
+        <location filename="../gui/nbrowserwindow.cpp" line="2534"/>
+        <source>Send Error</source>
+        <translation>发送错误</translation>
+    </message>
+    <message>
+        <location filename="../gui/nbrowserwindow.cpp" line="2534"/>
+        <source>Unable to send email.</source>
+        <translation>无法发送邮件。</translation>
+    </message>
+    <message>
         <source>Error loading document for printing.
 Printing aborted.</source>
-        <translation type="unfinished">载入文档出错。
+        <translation type="obsolete">载入文档出错。
 终止打印。</translation>
     </message>
     <message>
-        <location filename="../gui/nbrowserwindow.cpp" line="2341"/>
         <source>Print Error</source>
-        <translation type="unfinished">打印错误</translation>
+        <translation type="obsolete">打印错误</translation>
     </message>
     <message>
-        <location filename="../gui/nbrowserwindow.cpp" line="2671"/>
+        <location filename="../gui/nbrowserwindow.cpp" line="2965"/>
         <source>Decryption Error</source>
-        <translation type="unfinished">解密错误</translation>
+        <translation>解密错误</translation>
     </message>
     <message>
-        <location filename="../gui/nbrowserwindow.cpp" line="2672"/>
+        <location filename="../gui/nbrowserwindow.cpp" line="2966"/>
         <source>Unknown encryption method.
 Unable to decrypt.</source>
-        <translation type="unfinished">未知加密方法。
+        <translation>未知加密方法。
 无法解密。</translation>
     </message>
     <message>
-        <location filename="../gui/nbrowserwindow.cpp" line="2775"/>
+        <location filename="../gui/nbrowserwindow.cpp" line="3069"/>
         <source>Error</source>
-        <translation type="unfinished">错误</translation>
+        <translation>错误</translation>
     </message>
     <message>
-        <location filename="../gui/nbrowserwindow.cpp" line="2776"/>
+        <location filename="../gui/nbrowserwindow.cpp" line="3070"/>
         <source>Error Encrypting String.  Please verify you have Java installed.</source>
-        <translation type="unfinished">错误的加密字串。请确定Java已安装。</translation>
+        <translation>错误的加密字串。请确定Java已安装。</translation>
     </message>
     <message>
-        <location filename="../gui/nbrowserwindow.cpp" line="2942"/>
+        <location filename="../gui/nbrowserwindow.cpp" line="3236"/>
         <source>Spell Check Complete</source>
-        <translation type="unfinished">拼写检查完成</translation>
+        <translation>拼写检查完成</translation>
     </message>
     <message>
-        <location filename="../gui/nbrowserwindow.cpp" line="2942"/>
+        <location filename="../gui/nbrowserwindow.cpp" line="3236"/>
         <source>Spell Check Complete.</source>
-        <translation type="unfinished">拼写检查完成。</translation>
+        <translation>拼写检查完成。</translation>
     </message>
 </context>
 <context>
     <name>NMainMenuBar</name>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="59"/>
+        <location filename="../gui/nmainmenubar.cpp" line="60"/>
         <source>&amp;File</source>
-        <translation type="unfinished">文件(&amp;F)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="65"/>
-        <source>Print this note</source>
-        <translation type="unfinished">打印笔记</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="73"/>
-        <source>Backup database to a file</source>
-        <translation type="unfinished">备份数据库到文件</translation>
+        <translation>文件(&amp;F)</translation>
     </message>
     <message>
         <location filename="../gui/nmainmenubar.cpp" line="79"/>
-        <source>Restore from a backup</source>
-        <translation type="unfinished">从备份恢复</translation>
+        <source>Print this note</source>
+        <translation>打印笔记</translation>
     </message>
     <message>
         <location filename="../gui/nmainmenubar.cpp" line="87"/>
-        <source>Export selected notes to a file</source>
-        <translation type="unfinished">导出选中笔记到文件</translation>
+        <source>Backup database to a file</source>
+        <translation>备份数据库到文件</translation>
     </message>
     <message>
         <location filename="../gui/nmainmenubar.cpp" line="93"/>
+        <source>Restore from a backup</source>
+        <translation>从备份恢复</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="101"/>
+        <source>Export selected notes to a file</source>
+        <translation>导出选中笔记到文件</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="107"/>
         <source>Import notes from an export file</source>
-        <translation type="unfinished">从文件导入笔记</translation>
+        <translation>从文件导入笔记</translation>
     </message>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="113"/>
+        <location filename="../gui/nmainmenubar.cpp" line="127"/>
         <source>Switch to </source>
-        <translation type="unfinished">切换到</translation>
+        <translation>切换到</translation>
     </message>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="131"/>
+        <location filename="../gui/nmainmenubar.cpp" line="145"/>
         <source>Open/Close Notebooks</source>
-        <translation type="unfinished">打开/关闭笔记本</translation>
+        <translation>打开/关闭笔记本</translation>
     </message>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="139"/>
+        <location filename="../gui/nmainmenubar.cpp" line="153"/>
         <source>Close the program</source>
-        <translation type="unfinished">关闭程序</translation>
+        <translation>关闭程序</translation>
     </message>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="155"/>
+        <location filename="../gui/nmainmenubar.cpp" line="169"/>
         <source>&amp;Edit</source>
-        <translation type="unfinished">编辑(&amp;E)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="64"/>
-        <source>&amp;Print Note</source>
-        <translation type="unfinished">打印笔记(&amp;P)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="72"/>
-        <source>&amp;Backup Database</source>
-        <translation type="unfinished">备份数据库(&amp;B)</translation>
+        <translation>编辑(&amp;E)</translation>
     </message>
     <message>
         <location filename="../gui/nmainmenubar.cpp" line="78"/>
-        <source>&amp;Restore Database</source>
-        <translation type="unfinished">恢复数据库(&amp;R)</translation>
+        <source>&amp;Print Note</source>
+        <translation>打印笔记(&amp;P)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="64"/>
+        <source>Email Note</source>
+        <translation>发送笔记</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="65"/>
+        <source>Email a copy of this note</source>
+        <translation>发送笔记副本</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="71"/>
+        <source>Print Preview Note</source>
+        <translation>打印预览</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="72"/>
+        <source>Print preview of this note</source>
+        <translation>此笔记的打印预览</translation>
     </message>
     <message>
         <location filename="../gui/nmainmenubar.cpp" line="86"/>
-        <source>&amp;Export Notes</source>
-        <translation type="unfinished">导出笔记(&amp;E)</translation>
+        <source>&amp;Backup Database</source>
+        <translation>备份数据库(&amp;B)</translation>
     </message>
     <message>
         <location filename="../gui/nmainmenubar.cpp" line="92"/>
+        <source>&amp;Restore Database</source>
+        <translation>恢复数据库(&amp;R)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="100"/>
+        <source>&amp;Export Notes</source>
+        <translation>导出笔记(&amp;E)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="106"/>
         <source>&amp;Import Notes</source>
-        <translation type="unfinished">导入笔记(&amp;I)</translation>
+        <translation>导入笔记(&amp;I)</translation>
     </message>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="120"/>
+        <location filename="../gui/nmainmenubar.cpp" line="134"/>
         <source>&amp;Add Another User...</source>
-        <translation type="unfinished">添加账户(&amp;A)...</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="124"/>
-        <source>&amp;User Account Maintenance</source>
-        <translation type="unfinished">用户账户管理(&amp;U)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="130"/>
-        <source>&amp;Open/Close Notebooks</source>
-        <translation type="unfinished">打开/关闭笔记本(&amp;O)</translation>
+        <translation>添加账户(&amp;A)...</translation>
     </message>
     <message>
         <location filename="../gui/nmainmenubar.cpp" line="138"/>
+        <source>&amp;User Account Maintenance</source>
+        <translation>用户账户管理(&amp;U)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="144"/>
+        <source>&amp;Open/Close Notebooks</source>
+        <translation>打开/关闭笔记本(&amp;O)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="152"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">退出(&amp;X)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="160"/>
-        <source>&amp;Undo</source>
-        <translation type="unfinished">撤销(&amp;U)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="164"/>
-        <source>&amp;Redo</source>
-        <translation type="unfinished">重做(&amp;R)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="170"/>
-        <source>&amp;Cut</source>
-        <translation type="unfinished">剪切(&amp;C)</translation>
+        <translation>退出(&amp;X)</translation>
     </message>
     <message>
         <location filename="../gui/nmainmenubar.cpp" line="174"/>
-        <source>C&amp;opy</source>
-        <translation type="unfinished">复制(&amp;O)</translation>
+        <source>&amp;Undo</source>
+        <translation>撤销(&amp;U)</translation>
     </message>
     <message>
         <location filename="../gui/nmainmenubar.cpp" line="178"/>
-        <source>&amp;Paste</source>
-        <translation type="unfinished">粘贴(&amp;P)</translation>
+        <source>&amp;Redo</source>
+        <translation>重做(&amp;R)</translation>
     </message>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="182"/>
-        <source>Pas&amp;te as Unformatted Text</source>
-        <translation type="unfinished">粘贴为无格式文本(&amp;T)</translation>
+        <location filename="../gui/nmainmenubar.cpp" line="184"/>
+        <source>&amp;Cut</source>
+        <translation>剪切(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="186"/>
-        <source>Remo&amp;ve Formatting</source>
-        <translation type="unfinished">删除格式(&amp;V)</translation>
+        <location filename="../gui/nmainmenubar.cpp" line="188"/>
+        <source>C&amp;opy</source>
+        <translation>复制(&amp;O)</translation>
     </message>
     <message>
         <location filename="../gui/nmainmenubar.cpp" line="192"/>
-        <source>Select &amp;All</source>
-        <translation type="unfinished">全选(&amp;A)</translation>
+        <source>&amp;Paste</source>
+        <translation>粘贴(&amp;P)</translation>
     </message>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="198"/>
-        <source>F&amp;ind and Replace</source>
-        <translation type="unfinished">查找和替换(&amp;I)</translation>
+        <location filename="../gui/nmainmenubar.cpp" line="196"/>
+        <source>Pas&amp;te as Unformatted Text</source>
+        <translation>粘贴为无格式文本(&amp;T)</translation>
     </message>
     <message>
         <location filename="../gui/nmainmenubar.cpp" line="200"/>
-        <source>&amp;Search Notes</source>
-        <translation type="unfinished">搜索笔记(&amp;S)</translation>
+        <source>Remo&amp;ve Formatting</source>
+        <translation>删除格式(&amp;V)</translation>
     </message>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="205"/>
-        <source>&amp;Reset Search</source>
-        <translation type="unfinished">重置搜索(&amp;R)</translation>
+        <location filename="../gui/nmainmenubar.cpp" line="206"/>
+        <source>Select &amp;All</source>
+        <translation>全选(&amp;A)</translation>
     </message>
     <message>
         <location filename="../gui/nmainmenubar.cpp" line="212"/>
+        <source>F&amp;ind and Replace</source>
+        <translation>查找和替换(&amp;I)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="214"/>
+        <source>&amp;Search Notes</source>
+        <translation>搜索笔记(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="219"/>
+        <source>&amp;Reset Search</source>
+        <translation>重置搜索(&amp;R)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="226"/>
         <source>&amp;Find in Note</source>
-        <translation type="unfinished">笔记内查找(&amp;F)</translation>
+        <translation>笔记内查找(&amp;F)</translation>
     </message>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="218"/>
+        <location filename="../gui/nmainmenubar.cpp" line="232"/>
         <source>Find &amp;Next</source>
-        <translation type="unfinished">查找下一个(&amp;N)</translation>
+        <translation>查找下一个(&amp;N)</translation>
     </message>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="223"/>
+        <location filename="../gui/nmainmenubar.cpp" line="237"/>
         <source>Find &amp;Previous</source>
-        <translation type="unfinished">查找上一个(&amp;P)</translation>
+        <translation>查找上一个(&amp;P)</translation>
     </message>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="230"/>
+        <location filename="../gui/nmainmenubar.cpp" line="244"/>
         <source>Replace &amp;Within Note...</source>
-        <translation type="unfinished">笔记内替换(&amp;W)...</translation>
+        <translation>笔记内替换(&amp;W)...</translation>
     </message>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="240"/>
+        <location filename="../gui/nmainmenubar.cpp" line="254"/>
         <source>Preferences</source>
-        <translation type="unfinished">选项</translation>
+        <translation>选项</translation>
     </message>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="248"/>
+        <location filename="../gui/nmainmenubar.cpp" line="262"/>
         <source>&amp;View</source>
-        <translation type="unfinished">查看(&amp;V)</translation>
+        <translation>查看(&amp;V)</translation>
     </message>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="253"/>
+        <location filename="../gui/nmainmenubar.cpp" line="267"/>
         <source>Wide Note List</source>
-        <translation type="unfinished">宽笔记列表</translation>
+        <translation>宽笔记列表</translation>
     </message>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="258"/>
+        <location filename="../gui/nmainmenubar.cpp" line="272"/>
         <source>Narrow Note List</source>
-        <translation type="unfinished">窄笔记列表</translation>
+        <translation>窄笔记列表</translation>
     </message>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="265"/>
+        <location filename="../gui/nmainmenubar.cpp" line="279"/>
         <source>&amp;Show Source</source>
-        <translation type="unfinished">显示源码(&amp;S)</translation>
+        <translation>显示源码(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="269"/>
+        <location filename="../gui/nmainmenubar.cpp" line="283"/>
         <source>Note &amp;History</source>
-        <translation type="unfinished">笔记历史(&amp;H)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="275"/>
-        <source>Show &amp;Left Panel</source>
-        <translation type="unfinished">显示左边栏(&amp;L)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="282"/>
-        <source>Show &amp;Favorites</source>
-        <translation type="unfinished">显示收藏(&amp;F)</translation>
+        <translation>笔记历史(&amp;H)</translation>
     </message>
     <message>
         <location filename="../gui/nmainmenubar.cpp" line="289"/>
-        <source>Show &amp;Notebooks</source>
-        <translation type="unfinished">显示笔记本(&amp;N)</translation>
+        <source>Show &amp;Left Panel</source>
+        <translation>显示左边栏(&amp;L)</translation>
     </message>
     <message>
         <location filename="../gui/nmainmenubar.cpp" line="296"/>
-        <source>Show Ta&amp;gs</source>
-        <translation type="unfinished">显示标签(&amp;G)</translation>
+        <source>Show &amp;Favorites</source>
+        <translation>显示收藏(&amp;F)</translation>
     </message>
     <message>
         <location filename="../gui/nmainmenubar.cpp" line="303"/>
-        <source>Show Sa&amp;ved Searches</source>
-        <translation type="unfinished">显示已保存搜索(&amp;V)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="317"/>
-        <source>Show T&amp;rash</source>
-        <translation type="unfinished">显示回收站(&amp;R)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="324"/>
-        <source>Show N&amp;ote List</source>
-        <translation type="unfinished">显示笔记列表(&amp;O)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="331"/>
-        <source>Show Note &amp;Panel</source>
-        <translation type="unfinished">显示笔记面板(&amp;P)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="340"/>
-        <source>View Note &amp;Info</source>
-        <translation type="unfinished">显示笔记信息(&amp;I)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="344"/>
-        <source>View &amp;Toolbar</source>
-        <translation type="unfinished">显示工具栏(&amp;T)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="351"/>
-        <source>View Status&amp;bar</source>
-        <translation type="unfinished">显示状态栏(&amp;B)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="367"/>
-        <source>New &amp;Note</source>
-        <translation type="unfinished">新建笔记(&amp;N)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="372"/>
-        <source>New &amp;Webcam Note</source>
-        <translation type="unfinished">新建摄像头笔记(&amp;W)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="377"/>
-        <source>Dupl&amp;icate Note</source>
-        <translation type="unfinished">复制笔记(&amp;I)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="382"/>
-        <source>&amp;Delete</source>
-        <translation type="unfinished">删除(&amp;D)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="389"/>
-        <source>&amp;Spell Check</source>
-        <translation type="unfinished">拼写检查(&amp;S)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="397"/>
-        <source>&amp;Pin Note</source>
-        <translation type="unfinished">固定笔记(&amp;P)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="402"/>
-        <source>&amp;UnPin Note</source>
-        <translation type="unfinished">取消固定笔记(&amp;U)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="416"/>
-        <source>&amp;Synchronize</source>
-        <translation type="unfinished">同步(&amp;S)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="417"/>
-        <source>Synchronize with Evernote</source>
-        <translation type="unfinished">与Evernote同步</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="422"/>
-        <source>&amp;Disconnect</source>
-        <translation type="unfinished">断开连接(&amp;D)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="430"/>
-        <source>Pause &amp;Indexing</source>
-        <translation type="unfinished">暂停索引(&amp;I)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="431"/>
-        <source>Temporarily pause indexing</source>
-        <translation type="unfinished">暂停索引</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="438"/>
-        <source>Disable &amp;Editing</source>
-        <translation type="unfinished">禁止编辑(&amp;E)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="439"/>
-        <source>Temporarily disable note editing</source>
-        <translation type="unfinished">暂时禁止编辑笔记</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="446"/>
-        <source>A&amp;ccount</source>
-        <translation type="unfinished">账户(&amp;A)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="460"/>
-        <source>&amp;Reindex Database</source>
-        <translation type="unfinished">重建数据库索引(&amp;R)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="484"/>
-        <source>&amp;User&apos;s Guide</source>
-        <translation type="unfinished">用户指南(&amp;U)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="490"/>
-        <source>&amp;Icon Theme Information</source>
-        <translation type="unfinished">图标主题信息(&amp;I)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="362"/>
-        <source>&amp;Note</source>
-        <translation type="unfinished">笔记(&amp;N)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="411"/>
-        <source>&amp;Tools</source>
-        <translation type="unfinished">工具(&amp;T)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="423"/>
-        <source>Disconnect from Evernote</source>
-        <translation type="unfinished">从Evernote断开连接</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="447"/>
-        <source>Account information</source>
-        <translation type="unfinished">账户信息</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="454"/>
-        <source>&amp;Database Status</source>
-        <translation type="unfinished">数据库状态(&amp;D)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="455"/>
-        <source>Database Status</source>
-        <translation type="unfinished">数据库状态</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="461"/>
-        <source>Reindex all notes</source>
-        <translation type="unfinished">重建所有笔记索引</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="469"/>
-        <source>&amp;Import Folders</source>
-        <translation type="unfinished">导入文件夹(&amp;I)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="470"/>
-        <source>Import Folders</source>
-        <translation type="unfinished">导入文件夹</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="479"/>
-        <source>&amp;Help</source>
-        <translation type="unfinished">帮助(&amp;H)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="485"/>
-        <source>Open the user manual.</source>
-        <translation type="unfinished">打开用户手册。</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="491"/>
-        <source>View information about the current icon theme.</source>
-        <translation type="unfinished">查看当前图标主题信息。</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="508"/>
-        <source>Message &amp;Log</source>
-        <translation type="unfinished">消息日志(&amp;L)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="515"/>
-        <source>&amp;Evernote Account Page</source>
-        <translation type="unfinished">Evernote账户页面(&amp;E)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="520"/>
-        <source>Evernote &amp;Support</source>
-        <translation type="unfinished">Evernote支持(&amp;S)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="529"/>
-        <source>Evernote &amp;Trunk</source>
-        <translation type="unfinished">Evernote百宝箱(&amp;T)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="534"/>
-        <source>Evernote User &amp;Forum</source>
-        <translation type="unfinished">Evernote用户论坛(&amp;F)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="541"/>
-        <source>&amp;About</source>
-        <translation type="unfinished">关于(&amp;A)</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="575"/>
-        <source>Icon Theme</source>
-        <translation type="unfinished">图标主题</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="584"/>
-        <source>System Default</source>
-        <translation type="unfinished">系统默认</translation>
-    </message>
-    <message>
-        <location filename="../gui/nmainmenubar.cpp" line="509"/>
-        <source>View current program messages</source>
-        <translation type="unfinished">显示当前程序消息</translation>
+        <source>Show &amp;Notebooks</source>
+        <translation>显示笔记本(&amp;N)</translation>
     </message>
     <message>
         <location filename="../gui/nmainmenubar.cpp" line="310"/>
-        <source>Show &amp;Attribute Filter</source>
-        <translation type="unfinished">显示属性过滤器(&amp;A)</translation>
+        <source>Show Ta&amp;gs</source>
+        <translation>显示标签(&amp;G)</translation>
     </message>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="516"/>
-        <source>Go to your Evernote account page.</source>
-        <translation type="unfinished">跳转到Evernote账户页面。</translation>
+        <location filename="../gui/nmainmenubar.cpp" line="317"/>
+        <source>Show Sa&amp;ved Searches</source>
+        <translation>显示已保存搜索项(&amp;V)</translation>
     </message>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="521"/>
-        <source>Go to Evernote&apos;s support page</source>
-        <translation type="unfinished">跳转到Evernote支持页面</translation>
+        <location filename="../gui/nmainmenubar.cpp" line="331"/>
+        <source>Show T&amp;rash</source>
+        <translation>显示回收站(&amp;R)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="338"/>
+        <source>Show N&amp;ote List</source>
+        <translation>显示笔记列表(&amp;O)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="345"/>
+        <source>Show Note &amp;Panel</source>
+        <translation>显示笔记面板(&amp;P)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="354"/>
+        <source>View Note &amp;Info</source>
+        <translation>显示笔记信息(&amp;I)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="358"/>
+        <source>View &amp;Toolbar</source>
+        <translation>显示工具栏(&amp;T)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="365"/>
+        <source>View Status&amp;bar</source>
+        <translation>显示状态栏(&amp;B)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="381"/>
+        <source>New &amp;Note</source>
+        <translation>新建笔记(&amp;N)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="386"/>
+        <source>New &amp;Webcam Note</source>
+        <translation>新建摄像头笔记(&amp;W)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="391"/>
+        <source>Dupl&amp;icate Note</source>
+        <translation>复制笔记(&amp;I)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="396"/>
+        <source>&amp;Delete</source>
+        <translation>删除(&amp;D)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="403"/>
+        <source>&amp;Spell Check</source>
+        <translation>拼写检查(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="411"/>
+        <source>&amp;Pin Note</source>
+        <translation>固定笔记(&amp;P)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="416"/>
+        <source>&amp;UnPin Note</source>
+        <translation>取消固定笔记(&amp;U)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="430"/>
+        <source>&amp;Synchronize</source>
+        <translation>同步(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="431"/>
+        <source>Synchronize with Evernote</source>
+        <translation>与Evernote同步</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="436"/>
+        <source>&amp;Disconnect</source>
+        <translation>断开连接(&amp;D)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="444"/>
+        <source>Pause &amp;Indexing</source>
+        <translation>暂停索引(&amp;I)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="445"/>
+        <source>Temporarily pause indexing</source>
+        <translation>暂停索引</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="452"/>
+        <source>Disable &amp;Editing</source>
+        <translation>禁用编辑(&amp;E)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="453"/>
+        <source>Temporarily disable note editing</source>
+        <translation>暂时禁用笔记编辑</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="460"/>
+        <source>A&amp;ccount</source>
+        <translation>账户(&amp;A)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="474"/>
+        <source>&amp;Reindex Database</source>
+        <translation>重建数据库索引(&amp;R)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="498"/>
+        <source>&amp;User&apos;s Guide</source>
+        <translation>用户指南(&amp;U)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="504"/>
+        <source>&amp;Icon Theme Information</source>
+        <translation>图标主题信息(&amp;I)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="376"/>
+        <source>&amp;Note</source>
+        <translation>笔记(&amp;N)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="425"/>
+        <source>&amp;Tools</source>
+        <translation>工具(&amp;T)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="437"/>
+        <source>Disconnect from Evernote</source>
+        <translation>从Evernote断开连接</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="461"/>
+        <source>Account information</source>
+        <translation>账户信息</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="468"/>
+        <source>&amp;Database Status</source>
+        <translation>数据库状态(&amp;D)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="469"/>
+        <source>Database Status</source>
+        <translation>数据库状态</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="475"/>
+        <source>Reindex all notes</source>
+        <translation>重建所有笔记索引</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="483"/>
+        <source>&amp;Import Folders</source>
+        <translation>导入文件夹(&amp;I)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="484"/>
+        <source>Import Folders</source>
+        <translation>导入文件夹</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="493"/>
+        <source>&amp;Help</source>
+        <translation>帮助(&amp;H)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="499"/>
+        <source>Open the user manual.</source>
+        <translation>打开用户手册。</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="505"/>
+        <source>View information about the current icon theme.</source>
+        <translation>查看当前图标主题信息。</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="522"/>
+        <source>Message &amp;Log</source>
+        <translation>消息日志(&amp;L)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="529"/>
+        <source>&amp;Evernote Account Page</source>
+        <translation>Evernote账户页面(&amp;E)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="534"/>
+        <source>Evernote &amp;Support</source>
+        <translation>Evernote支持(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="543"/>
+        <source>Evernote &amp;Trunk</source>
+        <translation>Evernote百宝箱(&amp;T)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="548"/>
+        <source>Evernote User &amp;Forum</source>
+        <translation>Evernote用户论坛(&amp;F)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="555"/>
+        <source>&amp;About</source>
+        <translation>关于(&amp;A)</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="589"/>
+        <source>Icon Theme</source>
+        <translation>图标主题</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="598"/>
+        <source>System Default</source>
+        <translation>系统默认</translation>
     </message>
     <message>
         <location filename="../gui/nmainmenubar.cpp" line="523"/>
-        <source>Yinxiang Biji Support</source>
-        <translation type="unfinished">印象笔记支持</translation>
+        <source>View current program messages</source>
+        <translation>显示当前程序消息</translation>
     </message>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="524"/>
-        <source>Go to Yinxiang Biji&apos;s support page</source>
-        <translation type="unfinished">跳转到印象笔记支持页面</translation>
+        <location filename="../gui/nmainmenubar.cpp" line="324"/>
+        <source>Show &amp;Attribute Filter</source>
+        <translation>显示属性过滤器(&amp;A)</translation>
     </message>
     <message>
         <location filename="../gui/nmainmenubar.cpp" line="530"/>
-        <source>Go to Evernote Trunk</source>
-        <translation type="unfinished">跳转到Evernote百宝箱</translation>
+        <source>Go to your Evernote account page.</source>
+        <translation>跳转到Evernote账户页面。</translation>
     </message>
     <message>
         <location filename="../gui/nmainmenubar.cpp" line="535"/>
-        <source>Go to the Evernote user support forum.</source>
-        <translation type="unfinished">跳转到Evernote用户支持论坛。</translation>
+        <source>Go to Evernote&apos;s support page</source>
+        <translation>跳转到Evernote支持页面</translation>
     </message>
     <message>
-        <location filename="../gui/nmainmenubar.cpp" line="542"/>
+        <location filename="../gui/nmainmenubar.cpp" line="537"/>
+        <source>Yinxiang Biji Support</source>
+        <translation>印象笔记支持</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="538"/>
+        <source>Go to Yinxiang Biji&apos;s support page</source>
+        <translation>跳转到印象笔记支持页面</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="544"/>
+        <source>Go to Evernote Trunk</source>
+        <translation>跳转到Evernote百宝箱</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="549"/>
+        <source>Go to the Evernote user support forum.</source>
+        <translation>跳转到Evernote用户支持论坛。</translation>
+    </message>
+    <message>
+        <location filename="../gui/nmainmenubar.cpp" line="556"/>
         <source>About</source>
-        <translation type="unfinished">关于</translation>
+        <translation>关于</translation>
     </message>
 </context>
 <context>
     <name>NNotebookView</name>
     <message>
-        <location filename="../gui/nnotebookview.cpp" line="72"/>
+        <location filename="../gui/nnotebookview.cpp" line="68"/>
         <source>Notebooks</source>
-        <translation type="unfinished">笔记本</translation>
+        <translation>笔记本</translation>
     </message>
     <message>
-        <location filename="../gui/nnotebookview.cpp" line="89"/>
+        <location filename="../gui/nnotebookview.cpp" line="85"/>
         <source>Create New Notebook</source>
-        <translation type="unfinished">新建笔记本</translation>
+        <translation>新建笔记本</translation>
     </message>
     <message>
-        <location filename="../gui/nnotebookview.cpp" line="98"/>
+        <location filename="../gui/nnotebookview.cpp" line="94"/>
         <source>Delete</source>
-        <translation type="unfinished">删除</translation>
+        <translation>删除</translation>
     </message>
     <message>
-        <location filename="../gui/nnotebookview.cpp" line="106"/>
+        <location filename="../gui/nnotebookview.cpp" line="102"/>
         <source>Add to stack</source>
-        <translation type="unfinished">添加到组</translation>
+        <translation>添加到组</translation>
     </message>
     <message>
-        <location filename="../gui/nnotebookview.cpp" line="119"/>
+        <location filename="../gui/nnotebookview.cpp" line="115"/>
         <source>New stack</source>
-        <translation type="unfinished">新建组</translation>
+        <translation>新建组</translation>
+    </message>
+    <message>
+        <location filename="../gui/nnotebookview.cpp" line="118"/>
+        <source>Remove from stack</source>
+        <translation>从组中删除</translation>
     </message>
     <message>
         <location filename="../gui/nnotebookview.cpp" line="122"/>
-        <source>Remove from stack</source>
-        <translation type="unfinished">从组中删除</translation>
-    </message>
-    <message>
-        <location filename="../gui/nnotebookview.cpp" line="126"/>
         <source>Rename</source>
-        <translation type="unfinished">重命名</translation>
+        <translation>重命名</translation>
     </message>
     <message>
-        <location filename="../gui/nnotebookview.cpp" line="134"/>
+        <location filename="../gui/nnotebookview.cpp" line="130"/>
         <source>Properties</source>
-        <translation type="unfinished">性质</translation>
+        <translation>性质</translation>
     </message>
     <message>
-        <location filename="../gui/nnotebookview.cpp" line="629"/>
+        <location filename="../gui/nnotebookview.cpp" line="625"/>
         <source>Are you sure you want to delete this notebook?</source>
-        <translation type="unfinished">确定要删除这个笔记本？</translation>
+        <translation>确定要删除这个笔记本？</translation>
     </message>
     <message>
-        <location filename="../gui/nnotebookview.cpp" line="630"/>
+        <location filename="../gui/nnotebookview.cpp" line="626"/>
         <source>Verify Delete</source>
-        <translation type="unfinished">删除确认</translation>
+        <translation>删除确认</translation>
     </message>
     <message>
-        <location filename="../gui/nnotebookview.cpp" line="785"/>
+        <location filename="../gui/nnotebookview.cpp" line="781"/>
         <source>New Stack (</source>
-        <translation type="unfinished">新建组(</translation>
+        <translation>新建组(</translation>
     </message>
     <message>
-        <location filename="../gui/nnotebookview.cpp" line="785"/>
+        <location filename="../gui/nnotebookview.cpp" line="781"/>
         <source>)</source>
-        <translation type="unfinished">)</translation>
+        <translation>)</translation>
     </message>
 </context>
 <context>
     <name>NSearchView</name>
     <message>
-        <location filename="../gui/nsearchview.cpp" line="61"/>
+        <location filename="../gui/nsearchview.cpp" line="62"/>
         <source>Saved Searches</source>
-        <translation type="unfinished">已保存搜索</translation>
+        <translation>已保存搜索项</translation>
     </message>
     <message>
-        <location filename="../gui/nsearchview.cpp" line="73"/>
+        <location filename="../gui/nsearchview.cpp" line="74"/>
         <source>Create Saved Search</source>
-        <translation type="unfinished">创建保存搜索</translation>
+        <translation type="unfinished">创建保存的搜索项</translation>
     </message>
     <message>
-        <location filename="../gui/nsearchview.cpp" line="83"/>
+        <location filename="../gui/nsearchview.cpp" line="84"/>
         <source>Delete</source>
-        <translation type="unfinished">删除</translation>
+        <translation>删除</translation>
     </message>
     <message>
-        <location filename="../gui/nsearchview.cpp" line="91"/>
+        <location filename="../gui/nsearchview.cpp" line="92"/>
         <source>Rename</source>
-        <translation type="unfinished">重命名</translation>
+        <translation>重命名</translation>
     </message>
     <message>
-        <location filename="../gui/nsearchview.cpp" line="100"/>
+        <location filename="../gui/nsearchview.cpp" line="101"/>
         <source>Properties</source>
-        <translation type="unfinished">选项</translation>
-    </message>
-    <message>
-        <location filename="../gui/nsearchview.cpp" line="388"/>
-        <source>Are you sure you want to delete this saved search?</source>
-        <translation type="unfinished">确定要删除这个搜索？</translation>
+        <translation>性质</translation>
     </message>
     <message>
         <location filename="../gui/nsearchview.cpp" line="389"/>
+        <source>Are you sure you want to delete this saved search?</source>
+        <translation>确定要删除这个搜索项？</translation>
+    </message>
+    <message>
+        <location filename="../gui/nsearchview.cpp" line="390"/>
         <source>Verify Delete</source>
-        <translation type="unfinished">删除确认</translation>
+        <translation>删除确认</translation>
     </message>
 </context>
 <context>
     <name>NTabWidget</name>
     <message>
-        <location filename="../gui/ntabwidget.cpp" line="181"/>
+        <location filename="../gui/ntabwidget.cpp" line="183"/>
         <source>Untitled Note</source>
-        <translation type="unfinished">未命名笔记</translation>
+        <translation>未命名笔记</translation>
     </message>
     <message>
-        <location filename="../gui/ntabwidget.cpp" line="186"/>
-        <location filename="../gui/ntabwidget.cpp" line="252"/>
+        <location filename="../gui/ntabwidget.cpp" line="188"/>
+        <location filename="../gui/ntabwidget.cpp" line="254"/>
         <source>NixNote - </source>
-        <translation type="unfinished">NixNote - </translation>
+        <translation>NixNote - </translation>
     </message>
 </context>
 <context>
     <name>NTableView</name>
     <message>
-        <location filename="../gui/ntableview.cpp" line="198"/>
+        <location filename="../gui/ntableview.cpp" line="203"/>
         <source>Open Note</source>
-        <translation type="unfinished">打开笔记</translation>
+        <translation>打开笔记</translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="204"/>
+        <location filename="../gui/ntableview.cpp" line="209"/>
         <source>Open Note In New Tab</source>
-        <translation type="unfinished">在新标签页打开笔记</translation>
+        <translation>在新标签页打开笔记</translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="210"/>
+        <location filename="../gui/ntableview.cpp" line="215"/>
         <source>Open Note In New Window</source>
-        <translation type="unfinished">在新窗口打开笔记</translation>
-    </message>
-    <message>
-        <location filename="../gui/ntableview.cpp" line="217"/>
-        <source>Add Note</source>
-        <translation type="unfinished">添加笔记</translation>
+        <translation>在新窗口打开笔记</translation>
     </message>
     <message>
         <location filename="../gui/ntableview.cpp" line="222"/>
+        <source>Add Note</source>
+        <translation>添加笔记</translation>
+    </message>
+    <message>
+        <location filename="../gui/ntableview.cpp" line="227"/>
         <source>Delete Note</source>
-        <translation type="unfinished">删除笔记</translation>
+        <translation>删除笔记</translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="233"/>
+        <location filename="../gui/ntableview.cpp" line="238"/>
         <source>Restore Note</source>
-        <translation type="unfinished">恢复笔记</translation>
-    </message>
-    <message>
-        <location filename="../gui/ntableview.cpp" line="239"/>
-        <source>Copy Note Link</source>
-        <translation type="unfinished">复制笔记链接</translation>
+        <translation>恢复笔记</translation>
     </message>
     <message>
         <location filename="../gui/ntableview.cpp" line="244"/>
-        <source>Duplicate Note</source>
-        <translation type="unfinished">复制笔记</translation>
+        <source>Copy Note Link</source>
+        <translation>复制笔记链接</translation>
     </message>
     <message>
         <location filename="../gui/ntableview.cpp" line="249"/>
-        <source>Pin Note</source>
-        <translation type="unfinished">固定笔记</translation>
+        <source>Duplicate Note</source>
+        <translation>复制笔记</translation>
     </message>
     <message>
         <location filename="../gui/ntableview.cpp" line="254"/>
-        <source>Unpin Note</source>
-        <translation type="unfinished">取消固定笔记</translation>
+        <source>Pin Note</source>
+        <translation>固定笔记</translation>
     </message>
     <message>
         <location filename="../gui/ntableview.cpp" line="259"/>
+        <source>Unpin Note</source>
+        <translation>取消固定笔记</translation>
+    </message>
+    <message>
+        <location filename="../gui/ntableview.cpp" line="264"/>
         <source>Merge Notes</source>
-        <translation type="unfinished">合并笔记</translation>
+        <translation>合并笔记</translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="265"/>
+        <location filename="../gui/ntableview.cpp" line="270"/>
         <source>Title Color</source>
-        <translation type="unfinished">标题颜色</translation>
+        <translation>标题颜色</translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="269"/>
+        <location filename="../gui/ntableview.cpp" line="274"/>
         <source>White</source>
-        <translation type="unfinished">白色</translation>
+        <translation>白色</translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="272"/>
+        <location filename="../gui/ntableview.cpp" line="277"/>
         <source>Red</source>
-        <translation type="unfinished">红色</translation>
+        <translation>红色</translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="275"/>
+        <location filename="../gui/ntableview.cpp" line="280"/>
         <source>Blue</source>
-        <translation type="unfinished">蓝色</translation>
+        <translation>蓝色</translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="278"/>
+        <location filename="../gui/ntableview.cpp" line="283"/>
         <source>Green</source>
-        <translation type="unfinished">绿色</translation>
+        <translation>绿色</translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="281"/>
+        <location filename="../gui/ntableview.cpp" line="286"/>
         <source>Yellow</source>
-        <translation type="unfinished">黄色</translation>
+        <translation>黄色</translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="284"/>
+        <location filename="../gui/ntableview.cpp" line="289"/>
         <source>Black</source>
-        <translation type="unfinished">黑色</translation>
+        <translation>黑色</translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="287"/>
+        <location filename="../gui/ntableview.cpp" line="292"/>
         <source>Gray</source>
-        <translation type="unfinished">灰色</translation>
+        <translation>灰色</translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="290"/>
+        <location filename="../gui/ntableview.cpp" line="295"/>
         <source>Cyan</source>
-        <translation type="unfinished">蓝绿</translation>
+        <translation>蓝绿</translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="293"/>
+        <location filename="../gui/ntableview.cpp" line="298"/>
         <source>Magenta</source>
-        <translation type="unfinished">品红</translation>
+        <translation>品红</translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="591"/>
+        <location filename="../gui/ntableview.cpp" line="607"/>
         <source>Delete </source>
-        <translation type="unfinished">删除 </translation>
+        <translation>删除 </translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="594"/>
+        <location filename="../gui/ntableview.cpp" line="610"/>
         <source>Permanently delete </source>
-        <translation type="unfinished">永久删除 </translation>
+        <translation>永久删除 </translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="600"/>
+        <location filename="../gui/ntableview.cpp" line="616"/>
         <source>selected note?</source>
-        <translation type="unfinished">已选笔记？</translation>
+        <translation>已选笔记？</translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="605"/>
+        <location filename="../gui/ntableview.cpp" line="621"/>
         <source>Verify Delete</source>
-        <translation type="unfinished">删除确认</translation>
+        <translation>删除确认</translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="821"/>
+        <location filename="../gui/ntableview.cpp" line="886"/>
         <source>Unsynchronized Note</source>
-        <translation type="unfinished">未同步笔记</translation>
+        <translation>未同步笔记</translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="822"/>
+        <location filename="../gui/ntableview.cpp" line="887"/>
         <source>This note has never been synchronized.
 Using this in a note link can cause problems unless you synchronize it first.</source>
-        <translation type="unfinished">这个笔记从未同步过。
+        <translation>这个笔记从未同步过。
 在笔记链接中使用会导致问题，除非你先同步这个笔记。</translation>
     </message>
 </context>
 <context>
     <name>NTableViewHeader</name>
     <message>
-        <location filename="../gui/ntableviewheader.cpp" line="38"/>
+        <location filename="../gui/ntableviewheader.cpp" line="42"/>
         <source>Date Created</source>
-        <translation type="unfinished">创建日期</translation>
+        <translation>创建日期</translation>
     </message>
     <message>
-        <location filename="../gui/ntableviewheader.cpp" line="43"/>
+        <location filename="../gui/ntableviewheader.cpp" line="47"/>
         <source>Date Updated</source>
-        <translation type="unfinished">更新日期</translation>
+        <translation>更新日期</translation>
     </message>
     <message>
-        <location filename="../gui/ntableviewheader.cpp" line="48"/>
+        <location filename="../gui/ntableviewheader.cpp" line="52"/>
         <source>Title</source>
-        <translation type="unfinished">标题</translation>
+        <translation>标题</translation>
     </message>
     <message>
-        <location filename="../gui/ntableviewheader.cpp" line="53"/>
+        <location filename="../gui/ntableviewheader.cpp" line="57"/>
         <source>Notebook</source>
-        <translation type="unfinished">笔记本</translation>
+        <translation>笔记本</translation>
     </message>
     <message>
-        <location filename="../gui/ntableviewheader.cpp" line="58"/>
+        <location filename="../gui/ntableviewheader.cpp" line="62"/>
         <source>Tags</source>
-        <translation type="unfinished">标签</translation>
+        <translation>标签</translation>
     </message>
     <message>
-        <location filename="../gui/ntableviewheader.cpp" line="63"/>
+        <location filename="../gui/ntableviewheader.cpp" line="67"/>
         <source>Author</source>
-        <translation type="unfinished">作者</translation>
+        <translation>作者</translation>
     </message>
     <message>
-        <location filename="../gui/ntableviewheader.cpp" line="68"/>
+        <location filename="../gui/ntableviewheader.cpp" line="72"/>
         <source>Subject Date</source>
         <translation type="unfinished">主题日期</translation>
     </message>
     <message>
-        <location filename="../gui/ntableviewheader.cpp" line="73"/>
+        <location filename="../gui/ntableviewheader.cpp" line="77"/>
         <source>Source</source>
-        <translation type="unfinished">来源</translation>
+        <translation>来源</translation>
     </message>
     <message>
-        <location filename="../gui/ntableviewheader.cpp" line="78"/>
+        <location filename="../gui/ntableviewheader.cpp" line="82"/>
         <source>Source URL</source>
-        <translation type="unfinished">来源URL</translation>
+        <translation>来源URL</translation>
     </message>
     <message>
-        <location filename="../gui/ntableviewheader.cpp" line="83"/>
+        <location filename="../gui/ntableviewheader.cpp" line="87"/>
         <source>Latitude</source>
-        <translation type="unfinished">纬度</translation>
+        <translation>纬度</translation>
     </message>
     <message>
-        <location filename="../gui/ntableviewheader.cpp" line="88"/>
+        <location filename="../gui/ntableviewheader.cpp" line="92"/>
         <source>Longitude</source>
-        <translation type="unfinished">经度</translation>
+        <translation>经度</translation>
     </message>
     <message>
-        <location filename="../gui/ntableviewheader.cpp" line="93"/>
+        <location filename="../gui/ntableviewheader.cpp" line="97"/>
         <source>Altitude</source>
-        <translation type="unfinished">海拔</translation>
+        <translation>海拔</translation>
     </message>
     <message>
-        <location filename="../gui/ntableviewheader.cpp" line="98"/>
+        <location filename="../gui/ntableviewheader.cpp" line="102"/>
         <source>Has Encryption</source>
-        <translation type="unfinished">包含加密文本</translation>
+        <translation>包含加密文本</translation>
     </message>
     <message>
-        <location filename="../gui/ntableviewheader.cpp" line="103"/>
+        <location filename="../gui/ntableviewheader.cpp" line="107"/>
         <source>Has To-do</source>
-        <translation type="unfinished">包含待办事项</translation>
+        <translation>包含待办事项</translation>
     </message>
     <message>
-        <location filename="../gui/ntableviewheader.cpp" line="108"/>
+        <location filename="../gui/ntableviewheader.cpp" line="112"/>
         <source>Synchronized</source>
-        <translation type="unfinished">已同步</translation>
+        <translation>需要同步</translation>
     </message>
     <message>
-        <location filename="../gui/ntableviewheader.cpp" line="113"/>
+        <location filename="../gui/ntableviewheader.cpp" line="117"/>
         <source>Size</source>
-        <translation type="unfinished">大小</translation>
+        <translation>大小</translation>
     </message>
     <message>
-        <location filename="../gui/ntableviewheader.cpp" line="118"/>
+        <location filename="../gui/ntableviewheader.cpp" line="122"/>
         <source>Reminder</source>
-        <translation type="unfinished">提醒</translation>
+        <translation>提醒</translation>
     </message>
     <message>
-        <location filename="../gui/ntableviewheader.cpp" line="124"/>
+        <location filename="../gui/ntableviewheader.cpp" line="128"/>
         <source>Reminder Due</source>
-        <translation type="unfinished">提醒日期</translation>
+        <translation>提醒日期</translation>
     </message>
     <message>
-        <location filename="../gui/ntableviewheader.cpp" line="129"/>
+        <location filename="../gui/ntableviewheader.cpp" line="133"/>
         <source>Reminder Completed</source>
-        <translation type="unfinished">完成提醒</translation>
+        <translation>完成提醒</translation>
     </message>
     <message>
-        <location filename="../gui/ntableviewheader.cpp" line="134"/>
+        <location filename="../gui/ntableviewheader.cpp" line="138"/>
         <source>Pinned</source>
-        <translation type="unfinished">已固定</translation>
+        <translation>已固定</translation>
     </message>
     <message>
-        <location filename="../gui/ntableviewheader.cpp" line="139"/>
+        <location filename="../gui/ntableviewheader.cpp" line="143"/>
         <source>Thumbnail</source>
-        <translation type="unfinished">缩略图</translation>
+        <translation>缩略图</translation>
     </message>
 </context>
 <context>
     <name>NTagView</name>
     <message>
-        <location filename="../gui/ntagview.cpp" line="65"/>
-        <location filename="../gui/ntagview.cpp" line="159"/>
+        <location filename="../gui/ntagview.cpp" line="66"/>
+        <location filename="../gui/ntagview.cpp" line="160"/>
         <source>Tags from Personal</source>
-        <translation type="unfinished">个人标签</translation>
+        <translation>个人标签</translation>
     </message>
     <message>
-        <location filename="../gui/ntagview.cpp" line="89"/>
+        <location filename="../gui/ntagview.cpp" line="90"/>
         <source>Create New Tag</source>
-        <translation type="unfinished">新建标签</translation>
+        <translation>新建标签</translation>
     </message>
     <message>
-        <location filename="../gui/ntagview.cpp" line="98"/>
+        <location filename="../gui/ntagview.cpp" line="99"/>
         <source>Delete</source>
-        <translation type="unfinished">删除</translation>
+        <translation>删除</translation>
     </message>
     <message>
-        <location filename="../gui/ntagview.cpp" line="105"/>
+        <location filename="../gui/ntagview.cpp" line="106"/>
         <source>Rename</source>
-        <translation type="unfinished">重命名</translation>
+        <translation>重命名</translation>
     </message>
     <message>
-        <location filename="../gui/ntagview.cpp" line="108"/>
+        <location filename="../gui/ntagview.cpp" line="109"/>
         <source>Merge</source>
-        <translation type="unfinished">合并</translation>
+        <translation>合并</translation>
     </message>
     <message>
-        <location filename="../gui/ntagview.cpp" line="115"/>
+        <location filename="../gui/ntagview.cpp" line="116"/>
         <source>Hide Unassigned</source>
-        <translation type="unfinished">隐藏未分配标签</translation>
+        <translation>隐藏未分配标签</translation>
     </message>
     <message>
-        <location filename="../gui/ntagview.cpp" line="121"/>
+        <location filename="../gui/ntagview.cpp" line="122"/>
         <source>Properties</source>
-        <translation type="unfinished">性质</translation>
+        <translation>性质</translation>
     </message>
     <message>
-        <location filename="../gui/ntagview.cpp" line="157"/>
+        <location filename="../gui/ntagview.cpp" line="158"/>
         <source>Tags from </source>
-        <translation type="unfinished">标签来自 </translation>
+        <translation>标签来自 </translation>
     </message>
     <message>
-        <location filename="../gui/ntagview.cpp" line="358"/>
+        <location filename="../gui/ntagview.cpp" line="359"/>
         <source>-&lt;Missing Tag&gt;-</source>
         <translation type="unfinished">-&lt;缺少 标签&gt;-</translation>
     </message>
     <message>
-        <location filename="../gui/ntagview.cpp" line="696"/>
-        <source>Are you sure you want to merge these tags?</source>
-        <translation type="unfinished">确定要合并这些标签？</translation>
-    </message>
-    <message>
         <location filename="../gui/ntagview.cpp" line="697"/>
-        <source>Verify Merge</source>
-        <translation type="unfinished">合并确认</translation>
+        <source>Are you sure you want to merge these tags?</source>
+        <translation>确定要合并这些标签？</translation>
     </message>
     <message>
-        <location filename="../gui/ntagview.cpp" line="743"/>
-        <source>Are you sure you want to delete this tag?</source>
-        <translation type="unfinished">确定要删除标签？</translation>
+        <location filename="../gui/ntagview.cpp" line="698"/>
+        <source>Verify Merge</source>
+        <translation>合并确认</translation>
     </message>
     <message>
         <location filename="../gui/ntagview.cpp" line="744"/>
+        <source>Are you sure you want to delete this tag?</source>
+        <translation>确定要删除这个标签？</translation>
+    </message>
+    <message>
+        <location filename="../gui/ntagview.cpp" line="746"/>
+        <source>Are you sure you want to delete all selected tags?</source>
+        <translation>确定要删除所有已选标签？</translation>
+    </message>
+    <message>
+        <location filename="../gui/ntagview.cpp" line="747"/>
         <source>Verify Delete</source>
-        <translation type="unfinished">删除确认</translation>
+        <translation>删除确认</translation>
     </message>
 </context>
 <context>
@@ -2573,12 +2860,12 @@ Using this in a note link can cause problems unless you synchronize it first.</s
         <location filename="../gui/browserWidgets/ntitleeditor.cpp" line="123"/>
         <location filename="../gui/browserWidgets/ntitleeditor.cpp" line="137"/>
         <source>Untitled note</source>
-        <translation type="unfinished">未命名笔记</translation>
+        <translation>未命名笔记</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/ntitleeditor.cpp" line="134"/>
         <source>untitled note</source>
-        <translation type="unfinished">未命名笔记</translation>
+        <translation>未命名笔记</translation>
     </message>
 </context>
 <context>
@@ -2586,563 +2873,582 @@ Using this in a note link can cause problems unless you synchronize it first.</s
     <message>
         <location filename="../gui/ntrashtree.cpp" line="53"/>
         <source>Trash</source>
-        <translation type="unfinished">回收站</translation>
+        <translation>回收站</translation>
     </message>
     <message>
         <location filename="../gui/ntrashtree.cpp" line="65"/>
         <source>Restore Deleted Notes</source>
-        <translation type="unfinished">恢复已删除笔记</translation>
+        <translation>恢复已删除笔记</translation>
     </message>
     <message>
         <location filename="../gui/ntrashtree.cpp" line="68"/>
         <source>Empty Trash</source>
-        <translation type="unfinished">清空回收站</translation>
+        <translation>清空回收站</translation>
     </message>
     <message>
         <location filename="../gui/ntrashtree.cpp" line="238"/>
         <source>Verify Delete</source>
-        <translation type="unfinished">删除确认</translation>
+        <translation>删除确认</translation>
     </message>
     <message>
         <location filename="../gui/ntrashtree.cpp" line="239"/>
         <source>Are you sure you want to permanently delete these notes?</source>
-        <translation type="unfinished">确定要永久删除这些笔记？</translation>
+        <translation>确定要永久删除这些笔记？</translation>
     </message>
 </context>
 <context>
     <name>NWebView</name>
     <message>
-        <location filename="../gui/nwebview.cpp" line="55"/>
+        <location filename="../gui/nwebview.cpp" line="56"/>
         <source>Open</source>
-        <translation type="unfinished">打开</translation>
+        <translation>打开</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="60"/>
+        <location filename="../gui/nwebview.cpp" line="61"/>
         <source>Cut</source>
-        <translation type="unfinished">剪切</translation>
+        <translation>剪切</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="65"/>
+        <location filename="../gui/nwebview.cpp" line="66"/>
         <source>Copy</source>
-        <translation type="unfinished">复制</translation>
+        <translation>复制</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="70"/>
+        <location filename="../gui/nwebview.cpp" line="71"/>
         <source>Paste</source>
-        <translation type="unfinished">粘贴</translation>
+        <translation>粘贴</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="75"/>
+        <location filename="../gui/nwebview.cpp" line="76"/>
         <source>Paste as Unformatted Text</source>
-        <translation type="unfinished">粘贴为无格式文本</translation>
+        <translation>粘贴为无格式文本</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="80"/>
+        <location filename="../gui/nwebview.cpp" line="81"/>
         <source>Remove Formatting</source>
-        <translation type="unfinished">删除格式</translation>
+        <translation>删除格式</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="85"/>
+        <location filename="../gui/nwebview.cpp" line="86"/>
         <source>Copy Note URL</source>
-        <translation type="unfinished">复制笔记URL</translation>
+        <translation>复制笔记URL</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="92"/>
+        <location filename="../gui/nwebview.cpp" line="93"/>
         <source>Background Color</source>
-        <translation type="unfinished">背景颜色</translation>
+        <translation>背景颜色</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="94"/>
         <source>White</source>
-        <translation type="unfinished">白色</translation>
+        <translation type="obsolete">白色</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="97"/>
         <source>Red</source>
-        <translation type="unfinished">红色</translation>
+        <translation type="obsolete">红色</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="100"/>
         <source>Blue</source>
-        <translation type="unfinished">蓝色</translation>
+        <translation type="obsolete">蓝色</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="103"/>
         <source>Green</source>
-        <translation type="unfinished">绿色</translation>
+        <translation type="obsolete">绿色</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="106"/>
         <source>Yellow</source>
-        <translation type="unfinished">黄色</translation>
+        <translation type="obsolete">黄色</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="109"/>
         <source>Black</source>
-        <translation type="unfinished">黑色</translation>
+        <translation type="obsolete">黑色</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="112"/>
         <source>Gray</source>
-        <translation type="unfinished">灰色</translation>
+        <translation type="obsolete">灰色</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="115"/>
         <source>Purple</source>
-        <translation type="unfinished">紫色</translation>
+        <translation type="obsolete">紫色</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="118"/>
         <source>Brown</source>
-        <translation type="unfinished">棕色</translation>
+        <translation type="obsolete">棕色</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="121"/>
         <source>Orange</source>
-        <translation type="unfinished">橙色</translation>
+        <translation type="obsolete">橙色</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="124"/>
         <source>Powder Blue</source>
-        <translation type="unfinished">浅蓝</translation>
+        <translation type="obsolete">浅蓝</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="131"/>
+        <location filename="../gui/nwebview.cpp" line="113"/>
         <source>To-do</source>
-        <translation type="unfinished">待办事项</translation>
+        <translation>待办事项</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="138"/>
+        <location filename="../gui/nwebview.cpp" line="120"/>
         <source>HTML Entities</source>
-        <translation type="unfinished">HTML实体</translation>
+        <translation>HTML实体</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="145"/>
+        <location filename="../gui/nwebview.cpp" line="127"/>
         <source>Encrypted Selected Text</source>
-        <translation type="unfinished">加密已选文本</translation>
+        <translation>加密已选文本</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="150"/>
+        <location filename="../gui/nwebview.cpp" line="132"/>
+        <source>Insert Date &amp;&amp; Time</source>
+        <translation>插入日期时间</translation>
+    </message>
+    <message>
+        <location filename="../gui/nwebview.cpp" line="137"/>
         <source>Insert Hyperlink</source>
-        <translation type="unfinished">插入超链接</translation>
+        <translation>插入超链接</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="155"/>
+        <location filename="../gui/nwebview.cpp" line="142"/>
         <source>Quick Link</source>
-        <translation type="unfinished">快速链接</translation>
+        <translation>快速链接</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="160"/>
+        <location filename="../gui/nwebview.cpp" line="147"/>
         <source>Remove Hyperlink</source>
-        <translation type="unfinished">删除超链接</translation>
+        <translation>删除超链接</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="165"/>
+        <location filename="../gui/nwebview.cpp" line="152"/>
         <source>Attach File</source>
-        <translation type="unfinished">附件</translation>
+        <translation>添加附件</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="171"/>
+        <location filename="../gui/nwebview.cpp" line="158"/>
         <source>Insert LaTeX Formula</source>
-        <translation type="unfinished">插入LaTeX公式</translation>
+        <translation>插入LaTeX公式</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="177"/>
+        <location filename="../gui/nwebview.cpp" line="164"/>
         <source>Table</source>
-        <translation type="unfinished">表格</translation>
+        <translation>表格</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="180"/>
+        <location filename="../gui/nwebview.cpp" line="167"/>
         <source>Insert Table</source>
-        <translation type="unfinished">插入表格</translation>
+        <translation>插入表格</translation>
+    </message>
+    <message>
+        <location filename="../gui/nwebview.cpp" line="172"/>
+        <source>Insert Row</source>
+        <translation>插入行</translation>
+    </message>
+    <message>
+        <location filename="../gui/nwebview.cpp" line="176"/>
+        <source>Insert Column</source>
+        <translation>插入列</translation>
+    </message>
+    <message>
+        <location filename="../gui/nwebview.cpp" line="181"/>
+        <source>Delete Row</source>
+        <translation>删除行</translation>
     </message>
     <message>
         <location filename="../gui/nwebview.cpp" line="185"/>
-        <source>Insert Row</source>
-        <translation type="unfinished">插入行</translation>
+        <source>Delete Column</source>
+        <translation>删除列</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="189"/>
-        <source>Insert Column</source>
-        <translation type="unfinished">插入列</translation>
+        <location filename="../gui/nwebview.cpp" line="191"/>
+        <source>Image</source>
+        <translation>图像</translation>
     </message>
     <message>
         <location filename="../gui/nwebview.cpp" line="194"/>
-        <source>Delete Row</source>
-        <translation type="unfinished">删除行</translation>
-    </message>
-    <message>
-        <location filename="../gui/nwebview.cpp" line="198"/>
-        <source>Delete Column</source>
-        <translation type="unfinished">删除列</translation>
-    </message>
-    <message>
-        <location filename="../gui/nwebview.cpp" line="204"/>
-        <source>Image</source>
-        <translation type="unfinished">图像</translation>
-    </message>
-    <message>
-        <location filename="../gui/nwebview.cpp" line="207"/>
         <source>Save Image</source>
-        <translation type="unfinished">保存图像</translation>
+        <translation>保存图像</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="215"/>
+        <location filename="../gui/nwebview.cpp" line="202"/>
         <source>Rotate Left</source>
-        <translation type="unfinished">向左旋转</translation>
+        <translation>向左旋转</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="219"/>
+        <location filename="../gui/nwebview.cpp" line="206"/>
         <source>Rotate Right</source>
-        <translation type="unfinished">向右旋转</translation>
+        <translation>向右旋转</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="225"/>
+        <location filename="../gui/nwebview.cpp" line="212"/>
         <source>Save Attachment</source>
-        <translation type="unfinished">保存附件</translation>
+        <translation>保存附件</translation>
     </message>
     <message>
-        <location filename="../gui/nwebview.cpp" line="489"/>
-        <location filename="../gui/nwebview.cpp" line="519"/>
+        <location filename="../gui/nwebview.cpp" line="466"/>
+        <location filename="../gui/nwebview.cpp" line="496"/>
         <source>Save File</source>
-        <translation type="unfinished">保存文件</translation>
+        <translation>保存文件</translation>
     </message>
 </context>
 <context>
     <name>NixNote</name>
     <message>
-        <location filename="../nixnote.cpp" line="198"/>
+        <location filename="../nixnote.cpp" line="193"/>
         <source>Tidy Not Found</source>
-        <translation type="unfinished">未找到Tidy</translation>
+        <translation>未找到Tidy</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="198"/>
+        <location filename="../nixnote.cpp" line="193"/>
         <source>Tidy is not found on this system.
 Until tidy is installed you cannot save any notes.</source>
-        <translation type="unfinished">系统中未找到Tidy。
+        <translation>系统中未找到Tidy。
 在安装Tidy之前你无法保存任何笔记。</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="262"/>
+        <location filename="../nixnote.cpp" line="265"/>
         <source>ToolBar</source>
-        <translation type="unfinished">工具栏</translation>
+        <translation>工具栏</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="273"/>
+        <location filename="../nixnote.cpp" line="276"/>
         <source>Back</source>
-        <translation type="unfinished">后退</translation>
+        <translation>后退</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="274"/>
+        <location filename="../nixnote.cpp" line="277"/>
         <source>Next</source>
-        <translation type="unfinished">前进</translation>
+        <translation>前进</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="284"/>
+        <location filename="../nixnote.cpp" line="287"/>
         <source>All Notes</source>
-        <translation type="unfinished">所有笔记</translation>
-    </message>
-    <message>
-        <location filename="../nixnote.cpp" line="286"/>
-        <source>Sync</source>
-        <translation type="unfinished">同步</translation>
+        <translation>所有笔记</translation>
     </message>
     <message>
         <location filename="../nixnote.cpp" line="289"/>
+        <source>Sync</source>
+        <translation>同步</translation>
+    </message>
+    <message>
+        <location filename="../nixnote.cpp" line="292"/>
         <source>Print</source>
-        <translation type="unfinished">打印</translation>
+        <translation>打印</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="294"/>
+        <location filename="../nixnote.cpp" line="302"/>
         <source>New Text Note</source>
-        <translation type="unfinished">新建文字笔记</translation>
+        <translation>新建文字笔记</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="297"/>
+        <location filename="../nixnote.cpp" line="305"/>
         <source>New Webcam Note</source>
-        <translation type="unfinished">新建摄像头笔记</translation>
+        <translation>新建摄像头笔记</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="309"/>
+        <location filename="../nixnote.cpp" line="317"/>
         <source>Delete</source>
-        <translation type="unfinished">删除</translation>
+        <translation>删除</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="312"/>
+        <location filename="../nixnote.cpp" line="320"/>
         <source>Trunk</source>
-        <translation type="unfinished">百宝箱</translation>
+        <translation>百宝箱</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="314"/>
+        <location filename="../nixnote.cpp" line="322"/>
         <source>Usage</source>
-        <translation type="unfinished">用量</translation>
+        <translation>用量</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="492"/>
-        <location filename="../nixnote.cpp" line="2784"/>
+        <location filename="../nixnote.cpp" line="501"/>
+        <location filename="../nixnote.cpp" line="2870"/>
         <source>Screen Capture</source>
-        <translation type="unfinished">屏幕截图</translation>
+        <translation>屏幕截图</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="506"/>
+        <location filename="../nixnote.cpp" line="517"/>
         <source>Show/Hide</source>
-        <translation type="unfinished">显示/隐藏</translation>
+        <translation>显示/隐藏</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="518"/>
+        <location filename="../nixnote.cpp" line="529"/>
         <source>Close</source>
-        <translation type="unfinished">关闭</translation>
+        <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1617"/>
+        <location filename="../nixnote.cpp" line="1650"/>
         <source>Confirm Restore</source>
-        <translation type="unfinished">确认恢复</translation>
+        <translation>确认恢复</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1634"/>
+        <location filename="../nixnote.cpp" line="1666"/>
         <source>Restore Database</source>
-        <translation type="unfinished">恢复数据库</translation>
+        <translation>恢复数据库</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1636"/>
+        <location filename="../nixnote.cpp" line="1669"/>
         <source>Import Notes</source>
-        <translation type="unfinished">导入笔记</translation>
+        <translation>导入笔记</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1547"/>
-        <location filename="../nixnote.cpp" line="1639"/>
+        <location filename="../nixnote.cpp" line="1581"/>
+        <location filename="../nixnote.cpp" line="1667"/>
         <source>NixNote Export (*.nnex);;All Files (*.*)</source>
-        <translation type="unfinished">NixNote导出格式(*.nnex);;所有文件(*.*)</translation>
+        <translation>NixNote导出格式(*.nnex);;所有文件(*.*)</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="489"/>
+        <location filename="../nixnote.cpp" line="293"/>
+        <source>Print the current note</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../nixnote.cpp" line="295"/>
+        <source>Email</source>
+        <translation>发送邮件</translation>
+    </message>
+    <message>
+        <location filename="../nixnote.cpp" line="296"/>
+        <source>Email the current note</source>
+        <translation type="unfinished">发送当前笔记</translation>
+    </message>
+    <message>
+        <location filename="../nixnote.cpp" line="498"/>
         <source>Quick Note</source>
         <translation type="unfinished">快速笔记</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="499"/>
+        <location filename="../nixnote.cpp" line="508"/>
+        <source>Shortcut Notes</source>
+        <translation>已收藏笔记</translation>
+    </message>
+    <message>
+        <location filename="../nixnote.cpp" line="510"/>
         <source>Pinned Notes</source>
-        <translation type="unfinished">已固定笔记</translation>
+        <translation>已固定笔记</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="501"/>
+        <location filename="../nixnote.cpp" line="512"/>
         <source>Recently Updated Notes</source>
-        <translation type="unfinished">最近更新笔记</translation>
+        <translation>最近更新笔记</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1291"/>
-        <location filename="../nixnote.cpp" line="2078"/>
+        <location filename="../nixnote.cpp" line="1306"/>
+        <location filename="../nixnote.cpp" line="2142"/>
         <source>Log in to Evernote</source>
-        <translation type="unfinished">登录到Evernote</translation>
+        <translation>登录到Evernote</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1293"/>
-        <location filename="../nixnote.cpp" line="2080"/>
+        <location filename="../nixnote.cpp" line="1308"/>
+        <location filename="../nixnote.cpp" line="2144"/>
         <source>NixNote</source>
-        <translation type="unfinished">NixNote</translation>
+        <translation>NixNote</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1535"/>
-        <location filename="../nixnote.cpp" line="1579"/>
-        <location filename="../nixnote.cpp" line="1674"/>
+        <location filename="../nixnote.cpp" line="1566"/>
+        <location filename="../nixnote.cpp" line="1612"/>
+        <location filename="../nixnote.cpp" line="1709"/>
         <source>Error</source>
-        <translation type="unfinished">错误</translation>
+        <translation>错误</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1535"/>
+        <location filename="../nixnote.cpp" line="1566"/>
         <source>No notes selected.</source>
-        <translation type="unfinished">未选择笔记。</translation>
+        <translation>未选择笔记。</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1544"/>
+        <location filename="../nixnote.cpp" line="1573"/>
         <source>Backup Database</source>
-        <translation type="unfinished">备份数据库</translation>
+        <translation>备份数据库</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1546"/>
+        <location filename="../nixnote.cpp" line="1575"/>
         <source>Export Notes</source>
-        <translation type="unfinished">导出笔记</translation>
+        <translation>导出笔记</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1567"/>
+        <location filename="../nixnote.cpp" line="1600"/>
         <source>Performing backup</source>
-        <translation type="unfinished">正在备份</translation>
+        <translation>正在备份</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1569"/>
+        <location filename="../nixnote.cpp" line="1602"/>
         <source>Performing export</source>
-        <translation type="unfinished">正在导出</translation>
+        <translation>正在导出</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1586"/>
+        <location filename="../nixnote.cpp" line="1619"/>
         <source>Database backup complete.</source>
-        <translation type="unfinished">数据库备份完成。</translation>
+        <translation>数据库备份完成。</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1588"/>
+        <location filename="../nixnote.cpp" line="1621"/>
         <source>Note extract complete.</source>
-        <translation type="unfinished">笔记解压完成。</translation>
+        <translation>笔记解压完成。</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1614"/>
+        <location filename="../nixnote.cpp" line="1647"/>
         <source>This is used to restore a database from backups.
 It is HIGHLY recommended that this only be used to populate
 an empty database.  Restoring into a database that
  already has data can cause problems.
 
 Are you sure you want to continue?</source>
-        <translation type="unfinished">这个选项用于从备份恢复数据库。
+        <translation>这个选项用于从备份恢复数据库。
 强烈建议只用于空数据库，恢复到已有数据的数据库会导致问题。
 
 确定要继续吗？</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1641"/>
+        <location filename="../nixnote.cpp" line="1670"/>
         <source>NixNote Export (*.nnex);;Evernote Export (*.enex);;All Files (*.*)</source>
-        <translation type="unfinished">NixNote导出格式(*.nnex);;Evernote导出格式(*.enex);;所有文件(*.*)</translation>
+        <translation>NixNote导出格式(*.nnex);;Evernote导出格式(*.enex);;所有文件(*.*)</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1662"/>
+        <location filename="../nixnote.cpp" line="1697"/>
         <source>Restoring database</source>
-        <translation type="unfinished">正在恢复数据库</translation>
+        <translation>正在恢复数据库</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1664"/>
+        <location filename="../nixnote.cpp" line="1699"/>
         <source>Importing Notes</source>
-        <translation type="unfinished">正在导入笔记</translation>
+        <translation>正在导入笔记</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1696"/>
+        <location filename="../nixnote.cpp" line="1731"/>
         <source>Database has been restored.</source>
-        <translation type="unfinished">数据库已恢复。</translation>
+        <translation>数据库已恢复。</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1698"/>
+        <location filename="../nixnote.cpp" line="1733"/>
         <source>Notes have been imported.</source>
-        <translation type="unfinished">笔记已导入。</translation>
+        <translation>笔记已导入。</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1731"/>
+        <location filename="../nixnote.cpp" line="1766"/>
         <source>Sync Error</source>
-        <translation type="unfinished">同步错误</translation>
+        <translation>同步错误</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1731"/>
+        <location filename="../nixnote.cpp" line="1766"/>
         <source>Sync completed with errors.</source>
-        <translation type="unfinished">同步完成（有错误）。</translation>
+        <translation>同步完成（有错误）。</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1734"/>
+        <location filename="../nixnote.cpp" line="1769"/>
         <source>Sync Complete</source>
-        <translation type="unfinished">同步完成</translation>
+        <translation>同步完成</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="1734"/>
+        <location filename="../nixnote.cpp" line="1769"/>
         <source>Sync completed successfully.</source>
-        <translation type="unfinished">同步完成（成功）。</translation>
+        <translation>同步完成（成功）。</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="2098"/>
+        <location filename="../nixnote.cpp" line="1851"/>
+        <source>Untitled note</source>
+        <translation>未命名笔记</translation>
+    </message>
+    <message>
+        <location filename="../nixnote.cpp" line="2162"/>
         <source>This feature is only available to premium users.</source>
-        <translation type="unfinished">此功能仅高级用户可用。</translation>
+        <translation>此功能仅付费用户可用。</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="2099"/>
+        <location filename="../nixnote.cpp" line="2163"/>
         <source>Premium Feature</source>
-        <translation type="unfinished">高级功能</translation>
+        <translation>高级功能</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="2118"/>
+        <location filename="../nixnote.cpp" line="2182"/>
         <source>Error retrieving note.</source>
-        <translation type="unfinished">检索笔记错误。</translation>
+        <translation>检索笔记错误。</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="2119"/>
+        <location filename="../nixnote.cpp" line="2183"/>
         <source>Error retrieving note</source>
-        <translation type="unfinished">检索笔记错误</translation>
+        <translation>检索笔记错误</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="2141"/>
+        <location filename="../nixnote.cpp" line="2205"/>
         <source>Note restored</source>
-        <translation type="unfinished">笔记已恢复</translation>
+        <translation>笔记已恢复</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="2145"/>
+        <location filename="../nixnote.cpp" line="2209"/>
         <source>No versions of this note can be found.</source>
-        <translation type="unfinished">未找到此笔记的旧版本。</translation>
+        <translation>未找到此笔记的旧版本。</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="2146"/>
+        <location filename="../nixnote.cpp" line="2210"/>
         <source>Note Not Found</source>
-        <translation type="unfinished">未找到笔记</translation>
+        <translation>未找到笔记</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="2666"/>
+        <location filename="../nixnote.cpp" line="2752"/>
         <source>Switch to </source>
-        <translation type="unfinished">切换到</translation>
+        <translation>切换到</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="2839"/>
+        <location filename="../nixnote.cpp" line="2925"/>
         <source>Reindex Database</source>
-        <translation type="unfinished">重建数据库索引</translation>
+        <translation>重建数据库索引</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="2839"/>
+        <location filename="../nixnote.cpp" line="2925"/>
         <source>Reindex the entire database?</source>
-        <translation type="unfinished">重建整个数据库的索引？</translation>
+        <translation>重建整个数据库的索引？</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="2848"/>
+        <location filename="../nixnote.cpp" line="2934"/>
         <source>Notes will be reindexed.</source>
-        <translation type="unfinished">笔记将重新索引。</translation>
+        <translation>笔记将重新索引。</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="2876"/>
+        <location filename="../nixnote.cpp" line="2962"/>
         <source>Unable to find webcam or capture image.</source>
-        <translation type="unfinished">无法找到摄像头或捕获图像。</translation>
+        <translation>无法找到摄像头或捕获图像。</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="2877"/>
+        <location filename="../nixnote.cpp" line="2963"/>
         <source>Webcam Error</source>
-        <translation type="unfinished">摄像头错误</translation>
+        <translation>摄像头错误</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="3021"/>
+        <location filename="../nixnote.cpp" line="3107"/>
         <source>Delete </source>
-        <translation type="unfinished">删除</translation>
+        <translation>删除</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="3024"/>
+        <location filename="../nixnote.cpp" line="3110"/>
         <source>Permanently delete </source>
-        <translation type="unfinished">永久删除</translation>
+        <translation>永久删除</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="3028"/>
+        <location filename="../nixnote.cpp" line="3114"/>
         <source>this note?</source>
-        <translation type="unfinished">这个笔记？</translation>
+        <translation>这个笔记？</translation>
     </message>
     <message>
-        <location filename="../nixnote.cpp" line="3032"/>
+        <location filename="../nixnote.cpp" line="3118"/>
         <source>Verify Delete</source>
-        <translation type="unfinished">删除确认</translation>
+        <translation>删除确认</translation>
     </message>
 </context>
 <context>
     <name>NoteFormatter</name>
     <message>
-        <location filename="../html/noteformatter.cpp" line="564"/>
+        <location filename="../html/noteformatter.cpp" line="588"/>
         <source>File</source>
-        <translation type="unfinished">文件</translation>
+        <translation>文件</translation>
     </message>
     <message>
-        <location filename="../html/noteformatter.cpp" line="592"/>
+        <location filename="../html/noteformatter.cpp" line="619"/>
         <source>Bytes</source>
-        <translation type="unfinished"></translation>
+        <translation>Bytes</translation>
     </message>
     <message>
-        <location filename="../html/noteformatter.cpp" line="596"/>
+        <location filename="../html/noteformatter.cpp" line="623"/>
         <source>KB</source>
-        <translation type="unfinished"></translation>
+        <translation>KB</translation>
     </message>
 </context>
 <context>
@@ -3150,27 +3456,27 @@ Are you sure you want to continue?</source>
     <message>
         <location filename="../dialog/notehistoryselect.cpp" line="32"/>
         <source>Note History</source>
-        <translation type="unfinished">笔记历史</translation>
+        <translation>笔记历史</translation>
     </message>
     <message>
         <location filename="../dialog/notehistoryselect.cpp" line="33"/>
         <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
+        <translation>取消</translation>
     </message>
     <message>
         <location filename="../dialog/notehistoryselect.cpp" line="34"/>
         <source>Import</source>
-        <translation type="unfinished">导入</translation>
+        <translation>导入</translation>
     </message>
     <message>
         <location filename="../dialog/notehistoryselect.cpp" line="81"/>
         <source>Today</source>
-        <translation type="unfinished">今天</translation>
+        <translation>今天</translation>
     </message>
     <message>
         <location filename="../dialog/notehistoryselect.cpp" line="83"/>
         <source>Yesterday</source>
-        <translation type="unfinished">昨天</translation>
+        <translation>昨天</translation>
     </message>
 </context>
 <context>
@@ -3178,32 +3484,32 @@ Are you sure you want to continue?</source>
     <message>
         <location filename="../dialog/notebookproperties.cpp" line="36"/>
         <source>Notebook</source>
-        <translation type="unfinished">笔记本</translation>
+        <translation>笔记本</translation>
     </message>
     <message>
         <location filename="../dialog/notebookproperties.cpp" line="40"/>
         <source>Synchronized</source>
-        <translation type="unfinished">同步</translation>
+        <translation>同步</translation>
     </message>
     <message>
         <location filename="../dialog/notebookproperties.cpp" line="46"/>
         <source>Name</source>
-        <translation type="unfinished">名称</translation>
+        <translation>名称</translation>
     </message>
     <message>
         <location filename="../dialog/notebookproperties.cpp" line="53"/>
         <source>OK</source>
-        <translation type="unfinished">确定</translation>
+        <translation>确定</translation>
     </message>
     <message>
         <location filename="../dialog/notebookproperties.cpp" line="55"/>
         <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
+        <translation>取消</translation>
     </message>
     <message>
         <location filename="../dialog/notebookproperties.cpp" line="110"/>
         <source>Add Notebook</source>
-        <translation type="unfinished">添加笔记本</translation>
+        <translation>添加笔记本</translation>
     </message>
 </context>
 <context>
@@ -3211,42 +3517,42 @@ Are you sure you want to continue?</source>
     <message>
         <location filename="../oauth/oauthwindow.cpp" line="70"/>
         <source>Please Grant NixNote Access</source>
-        <translation type="unfinished">请授权给NixNote</translation>
+        <translation>请授权给NixNote</translation>
     </message>
     <message>
         <location filename="../oauth/oauthwindow.cpp" line="81"/>
         <source>SSL Support not found.  Aborting connection</source>
-        <translation type="unfinished">未找到SSL支持，终止连接</translation>
+        <translation>未找到SSL支持，终止连接</translation>
     </message>
     <message>
-        <location filename="../oauth/oauthwindow.cpp" line="128"/>
+        <location filename="../oauth/oauthwindow.cpp" line="132"/>
         <source>Error receiving temporary credentials</source>
-        <translation type="unfinished">接收临时证书错误</translation>
+        <translation>接收临时证书错误</translation>
     </message>
     <message>
-        <location filename="../oauth/oauthwindow.cpp" line="172"/>
+        <location filename="../oauth/oauthwindow.cpp" line="176"/>
         <source>Error receiving permanent credentials</source>
-        <translation type="unfinished">接收永久证书错误</translation>
+        <translation>接收永久证书错误</translation>
     </message>
     <message>
-        <location filename="../oauth/oauthwindow.cpp" line="215"/>
+        <location filename="../oauth/oauthwindow.cpp" line="219"/>
         <source>Error receiving authorization</source>
-        <translation type="unfinished">接收授权错误</translation>
+        <translation>接收授权错误</translation>
     </message>
 </context>
 <context>
     <name>PopplerViewer</name>
     <message>
-        <location filename="../gui/plugins/popplerviewer.cpp" line="57"/>
-        <location filename="../gui/plugins/popplerviewer.cpp" line="97"/>
+        <location filename="../gui/plugins/popplerviewer.cpp" line="79"/>
+        <location filename="../gui/plugins/popplerviewer.cpp" line="122"/>
         <source>Page </source>
-        <translation type="unfinished">第</translation>
+        <translation>第</translation>
     </message>
     <message>
-        <location filename="../gui/plugins/popplerviewer.cpp" line="57"/>
-        <location filename="../gui/plugins/popplerviewer.cpp" line="97"/>
+        <location filename="../gui/plugins/popplerviewer.cpp" line="79"/>
+        <location filename="../gui/plugins/popplerviewer.cpp" line="122"/>
         <source> of </source>
-        <translation type="unfinished">页, 共</translation>
+        <translation>页, 共</translation>
     </message>
 </context>
 <context>
@@ -3254,174 +3560,179 @@ Are you sure you want to continue?</source>
     <message>
         <location filename="../dialog/preferences/preferencesdialog.cpp" line="30"/>
         <source>User Settings</source>
-        <translation type="unfinished">用户设置</translation>
-    </message>
-    <message>
-        <location filename="../dialog/preferences/preferencesdialog.cpp" line="44"/>
-        <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
+        <translation>用户设置</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/preferencesdialog.cpp" line="45"/>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <location filename="../dialog/preferences/preferencesdialog.cpp" line="46"/>
         <source>OK</source>
-        <translation type="unfinished">确定</translation>
+        <translation>确定</translation>
     </message>
     <message>
-        <location filename="../dialog/preferences/preferencesdialog.cpp" line="85"/>
+        <location filename="../dialog/preferences/preferencesdialog.cpp" line="87"/>
         <source>Appearance</source>
-        <translation type="unfinished">外观</translation>
+        <translation>外观</translation>
     </message>
     <message>
-        <location filename="../dialog/preferences/preferencesdialog.cpp" line="91"/>
+        <location filename="../dialog/preferences/preferencesdialog.cpp" line="93"/>
         <source>Locale</source>
-        <translation type="unfinished">本地化</translation>
+        <translation>本地化</translation>
     </message>
     <message>
-        <location filename="../dialog/preferences/preferencesdialog.cpp" line="97"/>
+        <location filename="../dialog/preferences/preferencesdialog.cpp" line="99"/>
         <source>Search</source>
-        <translation type="unfinished">搜索</translation>
+        <translation>搜索</translation>
     </message>
     <message>
-        <location filename="../dialog/preferences/preferencesdialog.cpp" line="103"/>
+        <location filename="../dialog/preferences/preferencesdialog.cpp" line="105"/>
         <source>Sync</source>
-        <translation type="unfinished">同步</translation>
+        <translation>同步</translation>
     </message>
     <message>
-        <location filename="../dialog/preferences/preferencesdialog.cpp" line="108"/>
+        <location filename="../dialog/preferences/preferencesdialog.cpp" line="111"/>
+        <source>Email</source>
+        <translation>邮箱</translation>
+    </message>
+    <message>
+        <location filename="../dialog/preferences/preferencesdialog.cpp" line="117"/>
         <source>Debugging</source>
-        <translation type="unfinished">调试</translation>
+        <translation>调试</translation>
     </message>
 </context>
 <context>
     <name>QApplication</name>
     <message>
-        <location filename="../dialog/screencapture.cpp" line="109"/>
+        <location filename="../dialog/screencapture.cpp" line="108"/>
         <source>Use your mouse to draw a rectangle to screenshot or exit pressing
 any key or using the right or middle mouse buttons.</source>
-        <translation type="unfinished">用鼠标画矩形获取屏幕截图，按鼠标中键、右键或键盘任意键取消。</translation>
+        <translation>用鼠标画矩形获取屏幕截图，按鼠标中键、右键或键盘任意键取消。</translation>
     </message>
     <message>
-        <location filename="../dialog/screencapture.cpp" line="146"/>
+        <location filename="../dialog/screencapture.cpp" line="145"/>
         <source>%1 x %2 pixels </source>
-        <translation type="unfinished">%1 x %2 像素 </translation>
+        <translation>%1 x %2 像素 </translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../gui/ntableview.cpp" line="170"/>
-        <source>Title</source>
-        <translation type="unfinished">标题</translation>
-    </message>
-    <message>
-        <location filename="../gui/ntableview.cpp" line="171"/>
-        <source>Author</source>
-        <translation type="unfinished">作者</translation>
-    </message>
-    <message>
-        <location filename="../gui/ntableview.cpp" line="172"/>
-        <source>Notebook</source>
-        <translation type="unfinished">笔记本</translation>
-    </message>
-    <message>
-        <location filename="../gui/ntableview.cpp" line="173"/>
-        <source>Tags</source>
-        <translation type="unfinished">标签</translation>
-    </message>
-    <message>
-        <location filename="../gui/ntableview.cpp" line="174"/>
-        <source>Date Created</source>
-        <translation type="unfinished">创建日期</translation>
-    </message>
-    <message>
         <location filename="../gui/ntableview.cpp" line="175"/>
-        <source>Date Updated</source>
-        <translation type="unfinished">更新日期</translation>
+        <source>Title</source>
+        <translation>标题</translation>
     </message>
     <message>
         <location filename="../gui/ntableview.cpp" line="176"/>
+        <source>Author</source>
+        <translation>作者</translation>
+    </message>
+    <message>
+        <location filename="../gui/ntableview.cpp" line="177"/>
+        <source>Notebook</source>
+        <translation>笔记本</translation>
+    </message>
+    <message>
+        <location filename="../gui/ntableview.cpp" line="178"/>
+        <source>Tags</source>
+        <translation>标签</translation>
+    </message>
+    <message>
+        <location filename="../gui/ntableview.cpp" line="179"/>
+        <source>Date Created</source>
+        <translation>创建日期</translation>
+    </message>
+    <message>
+        <location filename="../gui/ntableview.cpp" line="180"/>
+        <source>Date Updated</source>
+        <translation>更新日期</translation>
+    </message>
+    <message>
+        <location filename="../gui/ntableview.cpp" line="181"/>
         <source>Subject Date</source>
         <translation type="unfinished">主题日期</translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="177"/>
+        <location filename="../gui/ntableview.cpp" line="182"/>
         <source>Deletion Date</source>
-        <translation type="unfinished">删除日期</translation>
+        <translation>删除日期</translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="178"/>
+        <location filename="../gui/ntableview.cpp" line="183"/>
         <source>Reminder</source>
-        <translation type="unfinished">提醒</translation>
+        <translation>提醒</translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="179"/>
+        <location filename="../gui/ntableview.cpp" line="184"/>
         <source>Reminder Due</source>
         <translation type="unfinished">提醒日期</translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="180"/>
+        <location filename="../gui/ntableview.cpp" line="185"/>
         <source>Reminder Completed</source>
         <translation type="unfinished">完成提醒 </translation>
     </message>
     <message>
-        <location filename="../gui/ntableview.cpp" line="181"/>
-        <source>Source</source>
-        <translation type="unfinished">来源</translation>
-    </message>
-    <message>
-        <location filename="../gui/ntableview.cpp" line="182"/>
-        <source>Source URL</source>
-        <translation type="unfinished">来源URL</translation>
-    </message>
-    <message>
-        <location filename="../gui/ntableview.cpp" line="183"/>
-        <source>Source Application</source>
-        <translation type="unfinished">来源应用</translation>
-    </message>
-    <message>
-        <location filename="../gui/ntableview.cpp" line="184"/>
-        <source>Longitude</source>
-        <translation type="unfinished">经度</translation>
-    </message>
-    <message>
-        <location filename="../gui/ntableview.cpp" line="185"/>
-        <source>Latitude</source>
-        <translation type="unfinished">纬度</translation>
-    </message>
-    <message>
         <location filename="../gui/ntableview.cpp" line="186"/>
-        <source>Altitude</source>
-        <translation type="unfinished">海拔</translation>
+        <source>Source</source>
+        <translation>来源</translation>
     </message>
     <message>
         <location filename="../gui/ntableview.cpp" line="187"/>
-        <source>Has Encryption</source>
-        <translation type="unfinished">包含加密文本</translation>
+        <source>Source URL</source>
+        <translation>来源URL</translation>
     </message>
     <message>
         <location filename="../gui/ntableview.cpp" line="188"/>
-        <source>Has To-do</source>
-        <translation type="unfinished">包含待办事项</translation>
+        <source>Source Application</source>
+        <translation>来源应用</translation>
     </message>
     <message>
         <location filename="../gui/ntableview.cpp" line="189"/>
-        <source>Sync</source>
-        <translation type="unfinished">同步</translation>
+        <source>Longitude</source>
+        <translation>经度</translation>
     </message>
     <message>
         <location filename="../gui/ntableview.cpp" line="190"/>
-        <source>Size</source>
-        <translation type="unfinished">大小</translation>
+        <source>Latitude</source>
+        <translation>纬度</translation>
     </message>
     <message>
         <location filename="../gui/ntableview.cpp" line="191"/>
-        <source>Thumbnail</source>
-        <translation type="unfinished">缩略图</translation>
+        <source>Altitude</source>
+        <translation>海拔</translation>
     </message>
     <message>
         <location filename="../gui/ntableview.cpp" line="192"/>
+        <source>Has Encryption</source>
+        <translation>包含加密文本</translation>
+    </message>
+    <message>
+        <location filename="../gui/ntableview.cpp" line="193"/>
+        <source>Has To-do</source>
+        <translation>包含待办事项</translation>
+    </message>
+    <message>
+        <location filename="../gui/ntableview.cpp" line="194"/>
+        <source>Sync</source>
+        <translation>需要同步</translation>
+    </message>
+    <message>
+        <location filename="../gui/ntableview.cpp" line="195"/>
+        <source>Size</source>
+        <translation>大小</translation>
+    </message>
+    <message>
+        <location filename="../gui/ntableview.cpp" line="196"/>
+        <source>Thumbnail</source>
+        <translation>缩略图</translation>
+    </message>
+    <message>
+        <location filename="../gui/ntableview.cpp" line="197"/>
         <source>Pinned</source>
-        <translation type="unfinished">已固定</translation>
+        <translation>已固定</translation>
     </message>
 </context>
 <context>
@@ -3429,25 +3740,25 @@ any key or using the right or middle mouse buttons.</source>
     <message>
         <location filename="../gui/browserWidgets/reminderbutton.cpp" line="35"/>
         <source>Mark as Done</source>
-        <translation type="unfinished">标记未已完成</translation>
+        <translation>标记未已完成</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/reminderbutton.cpp" line="36"/>
         <source>Change Date</source>
-        <translation type="unfinished">更改日期</translation>
+        <translation>更改提醒日期</translation>
     </message>
     <message>
         <location filename="../gui/browserWidgets/reminderbutton.cpp" line="37"/>
         <source>Clear Reminder</source>
-        <translation type="unfinished">清除提醒</translation>
+        <translation>清除提醒</translation>
     </message>
 </context>
 <context>
     <name>ReminderManager</name>
     <message>
-        <location filename="../reminders/remindermanager.cpp" line="87"/>
+        <location filename="../reminders/remindermanager.cpp" line="85"/>
         <source>Reminders Due</source>
-        <translation type="unfinished">提醒日期</translation>
+        <translation>提醒日期</translation>
     </message>
 </context>
 <context>
@@ -3455,12 +3766,12 @@ any key or using the right or middle mouse buttons.</source>
     <message>
         <location filename="../dialog/remindersetdialog.cpp" line="47"/>
         <source>OK</source>
-        <translation type="unfinished">确定</translation>
+        <translation>确定</translation>
     </message>
     <message>
         <location filename="../dialog/remindersetdialog.cpp" line="48"/>
         <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
+        <translation>取消</translation>
     </message>
 </context>
 <context>
@@ -3469,7 +3780,7 @@ any key or using the right or middle mouse buttons.</source>
         <location filename="../filters/remotequery.cpp" line="113"/>
         <location filename="../filters/remotequery.cpp" line="130"/>
         <source>Today</source>
-        <translation type="unfinished">今天</translation>
+        <translation>今天</translation>
     </message>
 </context>
 <context>
@@ -3477,32 +3788,32 @@ any key or using the right or middle mouse buttons.</source>
     <message>
         <location filename="../dialog/savedsearchproperties.cpp" line="35"/>
         <source>Saved Search</source>
-        <translation type="unfinished">已保存搜索</translation>
+        <translation>已保存搜索项</translation>
     </message>
     <message>
         <location filename="../dialog/savedsearchproperties.cpp" line="42"/>
         <source>Name</source>
-        <translation type="unfinished">名称</translation>
+        <translation>名称</translation>
     </message>
     <message>
         <location filename="../dialog/savedsearchproperties.cpp" line="43"/>
         <source>Query</source>
-        <translation type="unfinished">查询</translation>
+        <translation type="unfinished">关键词</translation>
     </message>
     <message>
         <location filename="../dialog/savedsearchproperties.cpp" line="51"/>
         <source>OK</source>
-        <translation type="unfinished">确定</translation>
+        <translation>确定</translation>
     </message>
     <message>
         <location filename="../dialog/savedsearchproperties.cpp" line="53"/>
         <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
+        <translation>取消</translation>
     </message>
     <message>
         <location filename="../dialog/savedsearchproperties.cpp" line="106"/>
         <source>Add Saved Search</source>
-        <translation type="unfinished">添加保存搜索</translation>
+        <translation type="unfinished">添加保存搜索项</translation>
     </message>
 </context>
 <context>
@@ -3510,7 +3821,7 @@ any key or using the right or middle mouse buttons.</source>
     <message>
         <location filename="../dialog/preferences/searchpreferences.cpp" line="34"/>
         <source>Index Attachments</source>
-        <translation type="unfinished">索引附件</translation>
+        <translation>索引附件</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/searchpreferences.cpp" line="39"/>
@@ -3523,37 +3834,37 @@ any key or using the right or middle mouse buttons.</source>
     <message>
         <location filename="../dialog/spellcheckdialog.cpp" line="35"/>
         <source>Spell Check</source>
-        <translation type="unfinished">拼写检查</translation>
+        <translation>拼写检查</translation>
     </message>
     <message>
         <location filename="../dialog/spellcheckdialog.cpp" line="50"/>
         <source>Suggestion</source>
-        <translation type="unfinished">拼写建议</translation>
+        <translation>拼写建议</translation>
     </message>
     <message>
         <location filename="../dialog/spellcheckdialog.cpp" line="56"/>
         <source>Replace</source>
-        <translation type="unfinished">替换</translation>
+        <translation>替换</translation>
     </message>
     <message>
         <location filename="../dialog/spellcheckdialog.cpp" line="57"/>
         <source>Ignore</source>
-        <translation type="unfinished">忽略</translation>
+        <translation>忽略</translation>
     </message>
     <message>
         <location filename="../dialog/spellcheckdialog.cpp" line="58"/>
         <source>Ignore All</source>
-        <translation type="unfinished">忽略所有</translation>
+        <translation>忽略所有</translation>
     </message>
     <message>
         <location filename="../dialog/spellcheckdialog.cpp" line="59"/>
         <source>Add To Dictionary</source>
-        <translation type="unfinished">添加到词典</translation>
+        <translation>添加到词典</translation>
     </message>
     <message>
         <location filename="../dialog/spellcheckdialog.cpp" line="66"/>
         <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
+        <translation>取消</translation>
     </message>
 </context>
 <context>
@@ -3561,7 +3872,7 @@ any key or using the right or middle mouse buttons.</source>
     <message>
         <location filename="../utilities/spellchecker.cpp" line="75"/>
         <source>Unable to find dictionaries.  Is Huntspell installed?</source>
-        <translation type="unfinished">无法找到词典。是否已安装Huntspell？</translation>
+        <translation>无法找到词典。是否已安装Huntspell？</translation>
     </message>
 </context>
 <context>
@@ -3569,77 +3880,77 @@ any key or using the right or middle mouse buttons.</source>
     <message>
         <location filename="../dialog/preferences/syncpreferences.cpp" line="34"/>
         <source>Sync automatically</source>
-        <translation type="unfinished">自动同步</translation>
+        <translation>自动同步</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/syncpreferences.cpp" line="38"/>
         <source>Every 15 minutes</source>
-        <translation type="unfinished">每15分钟</translation>
+        <translation>每15分钟</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/syncpreferences.cpp" line="39"/>
         <source>Every 30 minutes</source>
-        <translation type="unfinished">每30分钟</translation>
+        <translation>每30分钟</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/syncpreferences.cpp" line="40"/>
         <source>Every hour</source>
-        <translation type="unfinished">每小时</translation>
+        <translation>每小时</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/syncpreferences.cpp" line="41"/>
         <source>Every day</source>
-        <translation type="unfinished">每天</translation>
+        <translation>每天</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/syncpreferences.cpp" line="43"/>
         <source>Sync on startup</source>
-        <translation type="unfinished">启动时同步</translation>
+        <translation>启动时同步</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/syncpreferences.cpp" line="45"/>
         <source>Sync on shutdown</source>
-        <translation type="unfinished">关闭时同步</translation>
+        <translation>关闭时同步</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/syncpreferences.cpp" line="47"/>
         <source>Enable sync notifications</source>
-        <translation type="unfinished">启用同步通知</translation>
+        <translation>启用同步通知</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/syncpreferences.cpp" line="48"/>
         <source>Show successful syncs</source>
-        <translation type="unfinished">显示同步成功</translation>
+        <translation>显示同步成功</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/syncpreferences.cpp" line="50"/>
         <source>Enable Proxy*</source>
-        <translation type="unfinished">使用代理</translation>
+        <translation>使用代理</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/syncpreferences.cpp" line="51"/>
         <source>Proxy Hostname</source>
-        <translation type="unfinished">代理服务器</translation>
+        <translation>代理服务器</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/syncpreferences.cpp" line="52"/>
         <source>Proxy Port</source>
-        <translation type="unfinished">代理端口</translation>
+        <translation>代理端口</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/syncpreferences.cpp" line="53"/>
         <source>Proxy Username</source>
-        <translation type="unfinished">用户名</translation>
+        <translation>用户名</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/syncpreferences.cpp" line="54"/>
         <source>Proxy Password</source>
-        <translation type="unfinished">密码</translation>
+        <translation>密码</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/syncpreferences.cpp" line="55"/>
         <source>Note: Restart required</source>
-        <translation type="unfinished">注意：要求重启NixNote</translation>
+        <translation>注意：要求重启NixNote</translation>
     </message>
 </context>
 <context>
@@ -3647,43 +3958,43 @@ any key or using the right or middle mouse buttons.</source>
     <message>
         <location filename="../threads/syncrunner.cpp" line="131"/>
         <source>Beginning Sync</source>
-        <translation type="unfinished">开始同步</translation>
+        <translation>开始同步</translation>
     </message>
     <message>
         <location filename="../threads/syncrunner.cpp" line="139"/>
         <source>Downloading changes</source>
-        <translation type="unfinished">正在下载修改</translation>
+        <translation>正在下载修改</translation>
     </message>
     <message>
         <location filename="../threads/syncrunner.cpp" line="189"/>
         <source>Sync Complete Successfully</source>
-        <translation type="unfinished">同步完成（成功）</translation>
+        <translation>同步完成（成功）</translation>
     </message>
     <message>
         <location filename="../threads/syncrunner.cpp" line="235"/>
         <location filename="../threads/syncrunner.cpp" line="264"/>
         <source>Download </source>
-        <translation type="unfinished">已下载</translation>
+        <translation type="unfinished">已完成</translation>
     </message>
     <message>
         <location filename="../threads/syncrunner.cpp" line="235"/>
         <source>% complete for notebooks, tags, &amp; searches.</source>
-        <translation type="unfinished">% 的笔记本、标签和搜索项。</translation>
+        <translation type="unfinished">%的笔记本、标签和搜索项下载。</translation>
     </message>
     <message>
         <location filename="../threads/syncrunner.cpp" line="244"/>
         <source>Download complete for notebooks, tags, &amp; searches.  Downloading notes.</source>
-        <translation type="unfinished">下载笔记本、标签和搜索项完成。正在下载笔记。</translation>
+        <translation>下载笔记本、标签和搜索项完成。正在下载笔记...</translation>
     </message>
     <message>
         <location filename="../threads/syncrunner.cpp" line="264"/>
         <source>% complete.</source>
-        <translation type="unfinished">%已完成。</translation>
+        <translation type="unfinished">%。</translation>
     </message>
     <message>
         <location filename="../threads/syncrunner.cpp" line="277"/>
         <source>Download complete.</source>
-        <translation type="unfinished">下载完成。</translation>
+        <translation>下载完成。</translation>
     </message>
     <message>
         <location filename="../threads/syncrunner.cpp" line="690"/>
@@ -3694,24 +4005,24 @@ any key or using the right or middle mouse buttons.</source>
     <message>
         <location filename="../threads/syncrunner.cpp" line="690"/>
         <source>% complete for tags in shared notebook </source>
-        <translation type="unfinished">% 共享笔记本的标签</translation>
+        <translation type="unfinished">%的标签，来自共享笔记本</translation>
     </message>
     <message>
         <location filename="../threads/syncrunner.cpp" line="708"/>
         <source>Downloading notes for shared notebook </source>
-        <translation type="unfinished">正在下载笔记，来自共享笔记本</translation>
+        <translation>正在下载笔记，来自共享笔记本</translation>
     </message>
     <message>
         <location filename="../threads/syncrunner.cpp" line="730"/>
         <source>% complete for shared notebook </source>
-        <translation type="unfinished">% 已完成，来自共享笔记本</translation>
+        <translation type="unfinished">%，来自共享笔记本</translation>
     </message>
     <message>
         <location filename="../threads/syncrunner.cpp" line="690"/>
         <location filename="../threads/syncrunner.cpp" line="708"/>
         <location filename="../threads/syncrunner.cpp" line="730"/>
         <source>.</source>
-        <translation type="unfinished">。</translation>
+        <translation>。</translation>
     </message>
 </context>
 <context>
@@ -3719,7 +4030,7 @@ any key or using the right or middle mouse buttons.</source>
     <message>
         <location filename="../dialog/tabledialog.cpp" line="30"/>
         <source>Insert Table</source>
-        <translation type="unfinished">插入表格</translation>
+        <translation>插入表格</translation>
     </message>
     <message>
         <location filename="../dialog/tabledialog.cpp" line="34"/>
@@ -3729,37 +4040,37 @@ any key or using the right or middle mouse buttons.</source>
     <message>
         <location filename="../dialog/tabledialog.cpp" line="35"/>
         <source>Pixels</source>
-        <translation type="unfinished">像素</translation>
+        <translation>像素</translation>
     </message>
     <message>
         <location filename="../dialog/tabledialog.cpp" line="51"/>
         <source>Rows</source>
-        <translation type="unfinished">行</translation>
+        <translation>行</translation>
     </message>
     <message>
         <location filename="../dialog/tabledialog.cpp" line="53"/>
         <source>Columns</source>
-        <translation type="unfinished">列</translation>
+        <translation>列</translation>
     </message>
     <message>
         <location filename="../dialog/tabledialog.cpp" line="55"/>
         <source>Width</source>
-        <translation type="unfinished">宽度</translation>
+        <translation>宽度</translation>
     </message>
     <message>
         <location filename="../dialog/tabledialog.cpp" line="57"/>
         <source>Unit</source>
-        <translation type="unfinished">单位</translation>
+        <translation>单位</translation>
     </message>
     <message>
         <location filename="../dialog/tabledialog.cpp" line="64"/>
         <source>OK</source>
-        <translation type="unfinished">确定</translation>
+        <translation>确定</translation>
     </message>
     <message>
         <location filename="../dialog/tabledialog.cpp" line="67"/>
         <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
+        <translation>取消</translation>
     </message>
 </context>
 <context>
@@ -3767,7 +4078,7 @@ any key or using the right or middle mouse buttons.</source>
     <message>
         <location filename="../gui/browserWidgets/tageditornewtag.cpp" line="55"/>
         <source>Click to add tag...</source>
-        <translation type="unfinished">点击添加标签...</translation>
+        <translation>点击添加标签...</translation>
     </message>
 </context>
 <context>
@@ -3775,27 +4086,27 @@ any key or using the right or middle mouse buttons.</source>
     <message>
         <location filename="../dialog/tagproperties.cpp" line="36"/>
         <source>Tag</source>
-        <translation type="unfinished">标签</translation>
+        <translation>标签</translation>
     </message>
     <message>
         <location filename="../dialog/tagproperties.cpp" line="42"/>
         <source>Name</source>
-        <translation type="unfinished">名称</translation>
+        <translation>名称</translation>
     </message>
     <message>
         <location filename="../dialog/tagproperties.cpp" line="48"/>
         <source>OK</source>
-        <translation type="unfinished">确定</translation>
+        <translation>确定</translation>
     </message>
     <message>
         <location filename="../dialog/tagproperties.cpp" line="50"/>
         <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
+        <translation>取消</translation>
     </message>
     <message>
         <location filename="../dialog/tagproperties.cpp" line="102"/>
         <source>Add Tag</source>
-        <translation type="unfinished">添加标签</translation>
+        <translation>添加标签</translation>
     </message>
 </context>
 <context>
@@ -3803,7 +4114,7 @@ any key or using the right or middle mouse buttons.</source>
     <message>
         <location filename="../gui/browserWidgets/urleditor.cpp" line="43"/>
         <source>Click to set source URL...</source>
-        <translation type="unfinished">点击设置来源URL...</translation>
+        <translation>点击设置来源URL...</translation>
     </message>
 </context>
 <context>
@@ -3811,47 +4122,47 @@ any key or using the right or middle mouse buttons.</source>
     <message>
         <location filename="../dialog/watchfolderadd.cpp" line="47"/>
         <source>OK</source>
-        <translation type="unfinished">确定</translation>
+        <translation>确定</translation>
     </message>
     <message>
         <location filename="../dialog/watchfolderadd.cpp" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
+        <translation>取消</translation>
     </message>
     <message>
         <location filename="../dialog/watchfolderadd.cpp" line="55"/>
         <source>Directory</source>
-        <translation type="unfinished">目录</translation>
+        <translation>目录</translation>
     </message>
     <message>
         <location filename="../dialog/watchfolderadd.cpp" line="63"/>
         <source>Keep</source>
-        <translation type="unfinished">保留</translation>
+        <translation>保留</translation>
     </message>
     <message>
         <location filename="../dialog/watchfolderadd.cpp" line="64"/>
         <source>Delete</source>
-        <translation type="unfinished">删除</translation>
+        <translation>删除</translation>
     </message>
     <message>
         <location filename="../dialog/watchfolderadd.cpp" line="88"/>
         <source>Notebook</source>
-        <translation type="unfinished">笔记本</translation>
+        <translation>笔记本</translation>
     </message>
     <message>
         <location filename="../dialog/watchfolderadd.cpp" line="90"/>
         <source>After import</source>
-        <translation type="unfinished">导入后</translation>
+        <translation>导入后</translation>
     </message>
     <message>
         <location filename="../dialog/watchfolderadd.cpp" line="92"/>
         <source>Include subdirectories</source>
-        <translation type="unfinished">包含子目录</translation>
+        <translation>包含子目录</translation>
     </message>
     <message>
         <location filename="../dialog/watchfolderadd.cpp" line="99"/>
         <source>Add Import Folder</source>
-        <translation type="unfinished">添加导入文件夹</translation>
+        <translation>添加导入文件夹</translation>
     </message>
 </context>
 <context>
@@ -3859,64 +4170,64 @@ any key or using the right or middle mouse buttons.</source>
     <message>
         <location filename="../dialog/watchfolderdialog.cpp" line="38"/>
         <source>OK</source>
-        <translation type="unfinished">确定</translation>
+        <translation>确定</translation>
     </message>
     <message>
         <location filename="../dialog/watchfolderdialog.cpp" line="42"/>
         <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
+        <translation>取消</translation>
     </message>
     <message>
         <location filename="../dialog/watchfolderdialog.cpp" line="50"/>
         <source>Auto Import Folders</source>
-        <translation type="unfinished">自动导入文件夹</translation>
+        <translation>自动导入文件夹</translation>
     </message>
     <message>
         <location filename="../dialog/watchfolderdialog.cpp" line="62"/>
         <source>Add</source>
-        <translation type="unfinished">添加</translation>
+        <translation>添加</translation>
     </message>
     <message>
         <location filename="../dialog/watchfolderdialog.cpp" line="66"/>
         <source>Edit</source>
-        <translation type="unfinished">编辑</translation>
+        <translation>编辑</translation>
     </message>
     <message>
         <location filename="../dialog/watchfolderdialog.cpp" line="71"/>
         <location filename="../dialog/watchfolderdialog.cpp" line="162"/>
         <source>Delete</source>
-        <translation type="unfinished">删除</translation>
+        <translation>删除</translation>
     </message>
     <message>
         <location filename="../dialog/watchfolderdialog.cpp" line="112"/>
         <source>Directory</source>
-        <translation type="unfinished">目录</translation>
+        <translation>目录</translation>
     </message>
     <message>
         <location filename="../dialog/watchfolderdialog.cpp" line="113"/>
         <source>Target Notebook</source>
-        <translation type="unfinished">目标笔记本</translation>
+        <translation>目标笔记本</translation>
     </message>
     <message>
         <location filename="../dialog/watchfolderdialog.cpp" line="114"/>
         <location filename="../dialog/watchfolderdialog.cpp" line="159"/>
         <source>Keep</source>
-        <translation type="unfinished">保留</translation>
+        <translation>保留</translation>
     </message>
     <message>
         <location filename="../dialog/watchfolderdialog.cpp" line="115"/>
         <source>Include Subdirectories</source>
-        <translation type="unfinished">包含子目录</translation>
+        <translation>包含子目录</translation>
     </message>
     <message>
         <location filename="../dialog/watchfolderdialog.cpp" line="169"/>
         <source>Yes</source>
-        <translation type="unfinished">是</translation>
+        <translation>是</translation>
     </message>
     <message>
         <location filename="../dialog/watchfolderdialog.cpp" line="172"/>
         <source>No</source>
-        <translation type="unfinished">否</translation>
+        <translation>否</translation>
     </message>
 </context>
 <context>
@@ -3924,17 +4235,17 @@ any key or using the right or middle mouse buttons.</source>
     <message>
         <location filename="../dialog/webcamcapturedialog.cpp" line="40"/>
         <source>Webcam Capture</source>
-        <translation type="unfinished">摄像头捕获</translation>
+        <translation>摄像头捕获</translation>
     </message>
     <message>
         <location filename="../dialog/webcamcapturedialog.cpp" line="62"/>
         <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
+        <translation>取消</translation>
     </message>
     <message>
         <location filename="../dialog/webcamcapturedialog.cpp" line="63"/>
         <source>OK</source>
-        <translation type="unfinished">确定</translation>
+        <translation>确定</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
According to Gentoo Ebuild file naming rules, the suffix "beta" should write as "_beta" but "-beta". I modified the ebuild-generate script gentoo.sh. I also updated the dependence description in ebuild.