### PR TITLE
add lupdate to ebuild

### DIFF
--- a/package_scripts/gentoo/ebuild
+++ b/package_scripts/gentoo/ebuild
@@ -4,17 +4,18 @@
 
 EAPI=5
 
-inherit qmake-utils
+inherit qmake-utils versionator
 
 
 if [[ "${PV}" == "9999" ]] ; then
 	inherit git-r3
-	EGIT_REPO_URI="https://github.com/baumgarr/Nixnote2.git"
+	EGIT_REPO_URI="https://github.com/baumgarr/${PN}.git"
 	SLOT="0/9999"
 else
-	SRC_URI="https://github.com/baumgarr/Nixnote2/archive/__TAG__.tar.gz -> Nixnote2-__VERSION__.tar.gz"
+	MY_PV="$(replace_version_separator 2 '-')"
+	SRC_URI="https://github.com/baumgarr/${PN}/archive/v${MY_PV}.tar.gz -> ${PN}-${MY_PV}.tar.gz"
 	SLOT="0/2"   
-	S="${WORKDIR}/Nixnote2-__VERSION__"
+	S="${WORKDIR}/${PN}-${MY_PV}"
 fi
 
 DESCRIPTION="Nixnote - A clone of Evernote for Linux"

--- a/package_scripts/gentoo/ebuild
+++ b/package_scripts/gentoo/ebuild
@@ -47,7 +47,7 @@ RDEPEND="${DEPEND}
 		app-text/htmltidy"
 
 src_prepare() {
-
+	lupdate -pro NixNote2.pro -no-obsolete
 	lrelease NixNote2.pro
 	
 	if use qt4; then

--- a/package_scripts/gentoo/ebuild
+++ b/package_scripts/gentoo/ebuild
@@ -51,10 +51,10 @@ src_prepare() {
 	lrelease NixNote2.pro
 	
 	if use qt4; then
-		eqmake4 NixNote2.pro
+		eqmake4 NixNote2.pro || die "qmake failed"
 	fi
 	if use qt5; then
-		eqmake5 NixNote2.pro
+		eqmake5 NixNote2.pro || die "qmake failed"
 	fi
 }
 

--- a/translations/nixnote2_zh_CN.ts
+++ b/translations/nixnote2_zh_CN.ts
@@ -259,7 +259,7 @@
     <message>
         <location filename="../dialog/preferences/appearancepreferences.cpp" line="51"/>
         <source>Limit Editor to Web Fonts*</source>
-        <translation type="unfinished">编辑器只使用Web字体</translation>
+        <translation type="unfinished">编辑器只使用Web字体*</translation>
     </message>
     <message>
         <location filename="../dialog/preferences/appearancepreferences.cpp" line="55"/>


### PR DESCRIPTION
Sorry ,I was not circumspect enough and forgot the lupdate command. 

And, remove the dependence of "__TAG__", "__VERSION__" when generating ebuild, use versionator eclass function instead. Now, when the package version updates, what we need is just rename the ebuild file to the newer version.

Thanks to baumgarr for renaming the repository to lowercase letters.