### PR TITLE
Add Preferences options to control note list (table) appearance

### DIFF
--- a/dialog/preferences/appearancepreferences.cpp
+++ b/dialog/preferences/appearancepreferences.cpp
@@ -50,6 +50,8 @@ AppearancePreferences::AppearancePreferences(QWidget *parent) :
     newNoteFocusOnTitle = new QCheckBox(tr("Focus on Note Title on New Note"), this);
     forceWebFonts = new QCheckBox(tr("Limit Editor to Web Fonts*"), this);
     forceWebFonts->setChecked(global.forceWebFonts);
+    showNoteListGrid = new QCheckBox(tr("Show note list grid*"), this);
+    alternateNoteListColors = new QCheckBox(tr("Alternate note list colors*"), this);
 
     traySingleClickAction = new QComboBox();
     traySingleClickAction->addItem(tr("Show/Hide NixNote"), 0);
@@ -117,6 +119,8 @@ AppearancePreferences::AppearancePreferences(QWidget *parent) :
     mainLayout->addWidget(newNoteFocusOnTitle, row++, 1);
     mainLayout->addWidget(confirmDeletes, row, 0);
     mainLayout->addWidget(forceWebFonts, row++, 1);
+    mainLayout->addWidget(showNoteListGrid,row,0);
+    mainLayout->addWidget(alternateNoteListColors,row++,1);
 
     mainLayout->addWidget(defaultNotebookOnStartupLabel,row,0);
     mainLayout->addWidget(defaultNotebookOnStartup, row++,1);
@@ -170,6 +174,8 @@ AppearancePreferences::AppearancePreferences(QWidget *parent) :
     autoStart->setChecked(global.settings->value("autoStart", false).toBool());
     int defaultNotebook = global.settings->value("startupNotebook", UseLastViewedNotebook).toInt();
     defaultNotebookOnStartup->setCurrentIndex(defaultNotebook);
+    showNoteListGrid->setChecked(global.settings->value("showNoteListGrid", false).toBool());
+    alternateNoteListColors->setChecked(global.settings->value("alternateNoteListColors", true).toBool());
     global.settings->endGroup();
 
     connect(showTrayIcon, SIGNAL(clicked(bool)), this, SLOT(showTrayIconChanged(bool)));
@@ -222,6 +228,8 @@ void AppearancePreferences::saveValues() {
     global.settings->setValue("trayMiddleClickAction", trayMiddleClickAction->currentIndex());
     global.settings->setValue("systemNotifier", sysnotifier);
     global.settings->remove("trayDoubleClickAction");
+    global.settings->setValue("showNoteListGrid", showNoteListGrid->isChecked());
+    global.settings->setValue("alternateNoteListColors", alternateNoteListColors->isChecked());
     global.pdfPreview = showPDFs->isChecked();
     if (minimizeToTray!= NULL)
         global.settings->setValue("minimizeToTray", minimizeToTray->isChecked());

--- a/dialog/preferences/appearancepreferences.h
+++ b/dialog/preferences/appearancepreferences.h
@@ -68,6 +68,8 @@ public:
     QCheckBox *dynamicTotals;
     QCheckBox *disableEditingOnStartup;
     QCheckBox *newNoteFocusOnTitle;
+    QCheckBox *showNoteListGrid;
+    QCheckBox *alternateNoteListColors;
 
     enum DefaultNotebook {
         UseLastViewedNotebook = 0,

--- a/global.cpp
+++ b/global.cpp
@@ -275,7 +275,23 @@ void Global::setCloseToTray(bool value) {
     settings->endGroup();
 }
 
+// Should we whow the note list grid?
+bool Global::showNoteListGrid() {
+    bool showNoteListGrid;
+    settings->beginGroup("Appearance");
+    showNoteListGrid = settings->value("showNoteListGrid", false).toBool();
+    settings->endGroup();
+    return showNoteListGrid;
+}
 
+// Should we alternate the note list colors?
+bool Global::alternateNoteListColors() {
+    bool alternateNoteListColors;
+    settings->beginGroup("Appearance");
+    alternateNoteListColors = settings->value("alternateNoteListColors", true).toBool();
+    settings->endGroup();
+    return alternateNoteListColors;
+}
 
 // Save the position of a column in the note list.
 void Global::setColumnPosition(QString col, int position) {

--- a/global.h
+++ b/global.h
@@ -144,6 +144,8 @@ public:
     bool minimizeToTray();                 // Minimize it to tray rather than the task list.  We really just hide it.
     void setMinimizeToTray(bool value);    // Set if we should minimize it to the tray
     void setCloseToTray(bool value);       // Set if we should close it to the tray
+    bool showNoteListGrid();               // Should we whow the table grid?
+    bool alternateNoteListColors();        // Should we alternate the table colors?
     void setColumnPosition(QString col, int position);    // Save the order of a  note list's column.
     void setColumnWidth(QString col, int width);          // Save the width of a note list column
     int getColumnPosition(QString col);                   // Get the desired position of a note column

--- a/gui/ntableview.cpp
+++ b/gui/ntableview.cpp
@@ -310,6 +310,10 @@ NTableView::NTableView(QWidget *parent) :
     // Hide this column because it isn't really used.
     this->setColumnHidden(NOTE_TABLE_REMINDER_ORDER_POSITION, true);
 
+    // Set note list appearance
+    this->setShowGrid(global.showNoteListGrid());
+    this->setAlternatingRowColors(global.alternateNoteListColors());
+
     QLOG_TRACE() << "Exiting NTableView constructor";
 
 }


### PR DESCRIPTION
I added two options to control the note list (table) appearance. I set the default for no grid and alernating colors, because I think it looks much better, less rough. 

Let me know if you prefer the default to remain the old behavior (with grid, no alternating) and I'll change it.