### PR TITLE
fix window not active when show from trayicon

### DIFF
--- a/nixnote.cpp
+++ b/nixnote.cpp
@@ -2509,6 +2509,7 @@ void NixNote::toggleVisible() {
         if (isMinimized()) {
             setHidden(false);
             this->showNormal();
+	    this->activateWindow();
             this->setFocus();
             return;
         } else {


### PR DESCRIPTION
While "minimize to tray" is enable, nixnote main window can not get the focus when trayicon is clicked to show.
I try to fix this issue by adding "this->activateWindow()" in nixnote.cpp