### PR TITLE
fix single quote escaping in attachments

### DIFF
--- a/gui/nbrowserwindow.cpp
+++ b/gui/nbrowserwindow.cpp
@@ -2883,6 +2883,7 @@ void NBrowserWindow::attachFileSelected(QString filename) {
     buffer.append(tmpFile);
     buffer.append("\" />");
     buffer.append("</a>");
+    buffer.replace("\'", "&quot;");
 
     // Insert the actual attachment
     editor->page()->mainFrame()->evaluateJavaScript(


### PR DESCRIPTION
There's a problem when you trying to add attachments with a single quote in the filename. Fixed with replacing single quote with `&quot;` for HTML.