### PR TITLE
made pipeline `qmake && make && sudo make install` work

### DIFF
--- a/NixNote2.pro
+++ b/NixNote2.pro
@@ -435,3 +435,29 @@ HEADERS  += nixnote.h \
 
 QMAKE_CXXFLAGS +=-g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security
 QMAKE_LFLAGS += -Wl,-Bsymbolic-functions -Wl,-z,relro
+
+binary.path = /usr/bin/
+binary.files = nixnote2
+
+desktop.path = /usr/share/applications/
+desktop.files = nixnote2.desktop
+
+images.path = /usr/share/nixnote2/images
+images.files = images/*
+
+java.path = /usr/share/nixnote2/java
+java.files = java/*
+
+translations.path = /usr/share/nixnote2/translations
+translations.files = translations/*
+
+qss.path = /usr/share/nixnote2/qss
+qss.files = qss/*
+
+help.path = /usr/share/nixnote2/help
+help.files = help/*
+
+certs.path = /usr/share/nixnote2/certs
+certs.files = certs/*
+
+INSTALLS = binary desktop images java translations qss help certs


### PR DESCRIPTION
added INSTALLS to NixNote2.pro, that was enought.
Don't sure I found all needed data, but it works.

Main reason for this is that `qmake && make && sudo make install` pipeline is generally good. It is oblivious for expirienced *nix user and expected to be a good way to install from source. 

I also wrote an [ebuild](https://github.com/JelF/jelf-overlay/blob/dev/app-office/nixnote/nixnote-2.0_beta8.ebuild) using this patch and it works. As you can see, if this PR would be merged, ebuild could be reduced to a reference to git repo and commit sha, which is greate