### PR TITLE
Fix lintian warnings and info.

### DIFF
--- a/dialog/preferences/debugpreferences.cpp
+++ b/dialog/preferences/debugpreferences.cpp
@@ -37,7 +37,7 @@ DebugPreferences::DebugPreferences(QWidget *parent) :
     disableUploads = new QCheckBox(tr("Disable uploads to server."),this);
     disableImageHighlight = new QCheckBox(tr("Disable image search highlighting."), this);
     showLidColumn = new QCheckBox(tr("Show LID column (requires restart)."));
-    nonAsciiSortBug = new QCheckBox(tr("Disable Tag Sorting (usefull for non-ASCII sort bug)."));
+    nonAsciiSortBug = new QCheckBox(tr("Disable Tag Sorting (useful for non-ASCII sort bug)."));
     nonAsciiSortBug->setChecked(global.nonAsciiSortBug);
     global.settings->beginGroup("Debugging");
     disableUploads->setChecked(global.disableUploads);

--- a/html/enmlformatter.cpp
+++ b/html/enmlformatter.cpp
@@ -911,7 +911,7 @@ void EnmlFormatter::checkAttributes(QWebElement &e, QStringList valid) {
     QStringList attrs = e.attributeNames();
     for (int i=0; i<attrs.size(); i++) {
         if (!valid.contains(attrs[i])) {
-            QLOG_DEBUG() << "Removing invalid attibute: " << attrs[i];
+            QLOG_DEBUG() << "Removing invalid attribute: " << attrs[i];
             e.removeAttribute(attrs[i]);
         }
     }

--- a/man/nixnote2.1
+++ b/man/nixnote2.1
@@ -214,11 +214,11 @@ The notebook to place the note into.  If no notebook is given, the default noteb
 .IP --tag=<tag_name>
 Assign this particular tag to this note.  For multiple tags, use multiple --tag statements.  If  a tag does not exist it will be created.
 .IP --created=<creation_date>
-The date the note was created.  It should be in the format of YYYMMDDTHHMMSSZ where YYYY is the year, MM is the month, DD is the day, HH is the hour, MM is the minute, and SS is the second.  For example, 20151201T1302Z would be December 1, 2015 at 1:02pm.  All times are GMT time.  If ommitted, the current date is used.
+The date the note was created.  It should be in the format of YYYMMDDTHHMMSSZ where YYYY is the year, MM is the month, DD is the day, HH is the hour, MM is the minute, and SS is the second.  For example, 20151201T1302Z would be December 1, 2015 at 1:02pm.  All times are GMT time.  If omitted, the current date is used.
 .IP --updated=<creation_date>
-The date the note was last updated.  It should be in the format of YYYMMDDTHHMMSSZ where YYYY is the year, MM is the month, DD is the day, HH is the hour, MM is the minute, and SS is the second.  For example, 20151201T1302Z would be December 1, 2015 at 1:02pm.  All times are GMT time.  If ommitted, the current date is used.
+The date the note was last updated.  It should be in the format of YYYMMDDTHHMMSSZ where YYYY is the year, MM is the month, DD is the day, HH is the hour, MM is the minute, and SS is the second.  For example, 20151201T1302Z would be December 1, 2015 at 1:02pm.  All times are GMT time.  If omitted, the current date is used.
 .IP --updated=<creation_date>
-The date the note was last updated.  It should be in the format of YYYMMDDTHHMMSSZ where YYYY is the year, MM is the month, DD is the day, HH is the hour, MM is the minute, and SS is the second.  For example, 20151201T1302Z would be December 1, 2015 at 1:02pm.  All times are GMT time.  If ommitted, the current date is used.
+The date the note was last updated.  It should be in the format of YYYMMDDTHHMMSSZ where YYYY is the year, MM is the month, DD is the day, HH is the hour, MM is the minute, and SS is the second.  For example, 20151201T1302Z would be December 1, 2015 at 1:02pm.  All times are GMT time.  If omitted, the current date is used.
 .IP "--accountId=<id>
 The ID of the account to use upon startup.  Each account has an ID number assigned to it.  Look under File/Accounts for a list of accounts. If not specified, it defaults to the last used account. 
 .IP "--delimiter=<delimiter>"

--- a/nixnote2.desktop
+++ b/nixnote2.desktop
@@ -2,16 +2,16 @@
 Name=NixNote2
 Comment=Use with Evernote to remember everything
 GenericName=Evernote-clone
-Exec=/usr/bin/nixnote2
+Exec=nixnote2
 Icon=/usr/share/nixnote2/images/windowIcon.png
 StartupNotify=true
 Terminal=false
 Type=Application
-Categories=Network;
-MimeType=x-scheme-handler/evernote;
+Categories=Qt;Utility;Network;
+Keywords=NixNote2;Text;Evernote;note;
 
 Actions=NewNote;
 [Desktop Action NewNote]
 Name=New Note
-Exec=/usr/bin/nixnote2 --newNote
+Exec=nixnote2 --newNote
 OnlyShowIn=Unity;

--- a/translations/nixnote2_ca.ts
+++ b/translations/nixnote2_ca.ts
@@ -797,7 +797,7 @@
     </message>
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="40"/>
-        <source>Disable Tag Sorting (usefull for non-ASCII sort bug).</source>
+        <source>Disable Tag Sorting (useful for non-ASCII sort bug).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/nixnote2_cs_CZ.ts
+++ b/translations/nixnote2_cs_CZ.ts
@@ -811,7 +811,7 @@ posílejte prosím na &lt;i&gt;Milos.Kozina@email.cz&lt;/i&gt;.&lt;/p&gt;&lt;/sp
     </message>
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="40"/>
-        <source>Disable Tag Sorting (usefull for non-ASCII sort bug).</source>
+        <source>Disable Tag Sorting (useful for non-ASCII sort bug).</source>
         <translation>Vypnout řazení štítků (užitečné při problémech se řazením ne-ASCII znaků).</translation>
     </message>
     <message>

--- a/translations/nixnote2_da.ts
+++ b/translations/nixnote2_da.ts
@@ -797,7 +797,7 @@
     </message>
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="40"/>
-        <source>Disable Tag Sorting (usefull for non-ASCII sort bug).</source>
+        <source>Disable Tag Sorting (useful for non-ASCII sort bug).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/nixnote2_de.ts
+++ b/translations/nixnote2_de.ts
@@ -802,7 +802,7 @@
     </message>
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="40"/>
-        <source>Disable Tag Sorting (usefull for non-ASCII sort bug).</source>
+        <source>Disable Tag Sorting (useful for non-ASCII sort bug).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/nixnote2_es.ts
+++ b/translations/nixnote2_es.ts
@@ -797,7 +797,7 @@
     </message>
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="40"/>
-        <source>Disable Tag Sorting (usefull for non-ASCII sort bug).</source>
+        <source>Disable Tag Sorting (useful for non-ASCII sort bug).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/nixnote2_fr.ts
+++ b/translations/nixnote2_fr.ts
@@ -797,7 +797,7 @@
     </message>
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="40"/>
-        <source>Disable Tag Sorting (usefull for non-ASCII sort bug).</source>
+        <source>Disable Tag Sorting (useful for non-ASCII sort bug).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/nixnote2_ja.ts
+++ b/translations/nixnote2_ja.ts
@@ -802,7 +802,7 @@
     </message>
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="40"/>
-        <source>Disable Tag Sorting (usefull for non-ASCII sort bug).</source>
+        <source>Disable Tag Sorting (useful for non-ASCII sort bug).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/nixnote2_pl.ts
+++ b/translations/nixnote2_pl.ts
@@ -797,7 +797,7 @@
     </message>
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="40"/>
-        <source>Disable Tag Sorting (usefull for non-ASCII sort bug).</source>
+        <source>Disable Tag Sorting (useful for non-ASCII sort bug).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/nixnote2_pt.ts
+++ b/translations/nixnote2_pt.ts
@@ -797,7 +797,7 @@
     </message>
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="40"/>
-        <source>Disable Tag Sorting (usefull for non-ASCII sort bug).</source>
+        <source>Disable Tag Sorting (useful for non-ASCII sort bug).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/nixnote2_ru.ts
+++ b/translations/nixnote2_ru.ts
@@ -797,7 +797,7 @@
     </message>
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="40"/>
-        <source>Disable Tag Sorting (usefull for non-ASCII sort bug).</source>
+        <source>Disable Tag Sorting (useful for non-ASCII sort bug).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/nixnote2_sk.ts
+++ b/translations/nixnote2_sk.ts
@@ -797,7 +797,7 @@
     </message>
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="40"/>
-        <source>Disable Tag Sorting (usefull for non-ASCII sort bug).</source>
+        <source>Disable Tag Sorting (useful for non-ASCII sort bug).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/nixnote2_zh_CN.ts
+++ b/translations/nixnote2_zh_CN.ts
@@ -802,7 +802,7 @@
     </message>
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="40"/>
-        <source>Disable Tag Sorting (usefull for non-ASCII sort bug).</source>
+        <source>Disable Tag Sorting (useful for non-ASCII sort bug).</source>
         <translation type="unfinished">禁用标签排序(对非ASCII字符排序bug有效)。</translation>
     </message>
     <message>

--- a/translations/nixnote2_zh_TW.ts
+++ b/translations/nixnote2_zh_TW.ts
@@ -797,7 +797,7 @@
     </message>
     <message>
         <location filename="../dialog/preferences/debugpreferences.cpp" line="40"/>
-        <source>Disable Tag Sorting (usefull for non-ASCII sort bug).</source>
+        <source>Disable Tag Sorting (useful for non-ASCII sort bug).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/utilities/noteindexer.cpp
+++ b/utilities/noteindexer.cpp
@@ -220,7 +220,7 @@ void NoteIndexer::indexRecognition(qint32 reslid, Resource &r) {
             sql.exec();
         }
     }
-    QLOG_TRACE() << "Commiting";
+    QLOG_TRACE() << "Committing";
     sql.exec("commit");
     QLOG_TRACE_OUT();
 }


### PR DESCRIPTION
Checked the built deb file with `lintian -E -I --pedantic'.
This is the attempt to fix the problems, including:

* spell mistakes
* amendment for`nixnote2.desktop` file to fit freedesktop.org standard
