### PR TITLE
fix zh_TW translation tag typo

### DIFF
--- a/translations/nixnote2_zh_TW.ts
+++ b/translations/nixnote2_zh_TW.ts
@@ -2792,7 +2792,7 @@ Unable to decrypt.</source>
     <message>
         <location filename="../gui/ntableview.cpp" line="248"/>
         <source>Duplicate Note</source>
-        <translatio>復制記事</translation>
+        <translation>復制記事</translation>
     </message>
     <message>
         <location filename="../gui/ntableview.cpp" line="253"/>


### PR DESCRIPTION
Which causes `lrelease` call to fail.