### PR TITLE
Add socks5 proxy support and update gentoo ebuild

### DIFF
--- a/dialog/preferences/syncpreferences.cpp
+++ b/dialog/preferences/syncpreferences.cpp
@@ -86,7 +86,7 @@ SyncPreferences::SyncPreferences(QWidget *parent) :
     mainLayout->addWidget(userId,8,1);
     mainLayout->addWidget(passwordLabel,9,0);
     mainLayout->addWidget(password,9,1);
-    mainLayout->addWidget(restartLabel,4,1);
+    mainLayout->addWidget(restartLabel,4,2);
     mainLayout->setAlignment(Qt::AlignTop);
 
     global.settings->beginGroup("Sync");

--- a/dialog/preferences/syncpreferences.cpp
+++ b/dialog/preferences/syncpreferences.cpp
@@ -48,6 +48,7 @@ SyncPreferences::SyncPreferences(QWidget *parent) :
     showGoodSyncMessagesInTray = new QCheckBox(tr("Show successful syncs"), this);
 
     enableProxy = new QCheckBox(tr("Enable Proxy*"), this);
+    enableSocks5 = new QCheckBox(tr("Enable Socks5"),this);
     QLabel *hostLabel = new QLabel(tr("Proxy Hostname"), this);
     QLabel *portLabel = new QLabel(tr("Proxy Port"), this);
     QLabel *userLabel = new QLabel(tr("Proxy Username"), this);
@@ -60,6 +61,7 @@ SyncPreferences::SyncPreferences(QWidget *parent) :
     password = new QLineEdit(this);
 
     enableProxy->setChecked(global.isProxyEnabled());
+    enableSocks5->setChecked(global.isSocks5Enabled());
     host->setText(global.getProxyHost());
     port->setText(QString::number(global.getProxyPort()));
     port->setInputMask("00000");
@@ -75,6 +77,7 @@ SyncPreferences::SyncPreferences(QWidget *parent) :
     mainLayout->addWidget(syncInterval, 3,1);
 
     mainLayout->addWidget(enableProxy,4,0);
+    mainLayout->addWidget(enableSocks5,4,1);
     mainLayout->addWidget(hostLabel,6,0);
     mainLayout->addWidget(host, 6,1);
     mainLayout->addWidget(portLabel,7,0);
@@ -152,6 +155,7 @@ void SyncPreferences::saveValues() {
     global.showGoodSyncMessagesInTray = showGoodSyncMessagesInTray->isChecked();
 
     global.setProxyEnabled(enableProxy->isChecked());
+    global.setSocks5Enabled(enableSocks5->isChecked());
     global.setProxyHost(host->text().trimmed());
     global.setProxyPort(port->text().toInt());
     global.setProxyUserid(userId->text().trimmed());
@@ -164,6 +168,7 @@ void SyncPreferences::proxyCheckboxAltered(int state) {
     bool value = false;
     if (state == Qt::Checked)
         value = true;
+    enableSocks5->setEnabled(value);
     host->setEnabled(value);
     port->setEnabled(value);
     userId->setEnabled(value);

--- a/dialog/preferences/syncpreferences.h
+++ b/dialog/preferences/syncpreferences.h
@@ -38,6 +38,7 @@ private:
     QCheckBox *syncOnShutdown;
 
     QCheckBox *enableProxy;
+    QCheckBox *enableSocks5;
     QLineEdit *userId;
     QLineEdit *password;
     QLineEdit *port;

--- a/global.cpp
+++ b/global.cpp
@@ -983,6 +983,20 @@ bool Global::isProxyEnabled() {
     return value;
 }
 
+// Set the Sock5 proxy
+void Global::setSocks5Enabled(bool value) {
+    settings->beginGroup("Proxy");
+    settings->setValue("enabled", value);
+    settings->endGroup();
+}
+
+// Get the Socks5 proxy
+bool Global::isSocks5Enabled() {
+    settings->beginGroup("Proxy");
+    bool value = settings->value("enabled", false).toBool();
+    settings->endGroup();
+    return value;
+}
 
 
 // Mouse middle click actions

--- a/global.h
+++ b/global.h
@@ -214,7 +214,9 @@ public:
     QString getProxyPassword();
     QString getProxyUserid();
     bool isProxyEnabled();
+    bool isSocks5Enabled();
     void setProxyEnabled(bool value);
+    void setSocks5Enabled(bool value);
     QString systemNotifier();
 
     // Search Behavior

--- a/main.cpp
+++ b/main.cpp
@@ -222,7 +222,10 @@ int main(int argc, char *argv[])
 
     // Setup the proxy
     QNetworkProxy proxy;
-    proxy.setType(QNetworkProxy::HttpProxy);
+    if (global.isSocks5Enabled())
+	proxy.setType(QNetworkProxy::Socks5Proxy);
+    else
+    	proxy.setType(QNetworkProxy::HttpProxy);
     if (global.isProxyEnabled()) {
         QString host = global.getProxyHost();
         int port = global.getProxyPort();

--- a/package_scripts/gentoo/ebuild
+++ b/package_scripts/gentoo/ebuild
@@ -25,8 +25,8 @@ KEYWORDS="~amd64 ~x86"
 IUSE="qt4 qt5 +opencv3"
 
 REQUIRED_USE="^^ ( qt4 qt5 )
-		      qt5? ( opencv3 )
-		      "
+	      qt5? ( opencv3 )
+	      "
 		
 DEPEND="dev-libs/boost
 	      app-text/hunspell
@@ -37,8 +37,6 @@ DEPEND="dev-libs/boost
 		      dev-qt/qtcore:4
 		      dev-qt/qtgui:4
 		      dev-qt/qtsql:4
-		      opencv3? ( media-libs/opencv:0/3.0[qt4] )
-		      !opencv3? ( media-libs/opencv:0/2.4[qt4] )
 	      )
 	      qt5? (
 		      app-text/poppler[qt5]
@@ -46,11 +44,18 @@ DEPEND="dev-libs/boost
 		      dev-qt/qtcore:5
 		      dev-qt/qtgui:5
 		      dev-qt/qtsql:5
-		      media-libs/opencv[qt5]
 	      )
+	      
+	      opencv3? ( media-libs/opencv:0/3.0 )
+	      !opencv3? ( media-libs/opencv:0/2.4 )
 	      "
 RDEPEND="${DEPEND}
 		app-text/htmltidy"
+
+# After commit 836482e, NixNote2 can not be compiled with qt4 any more  
+if [[ "${PV}" == *9999* ]] && use qt4; then               
+   EGIT_COMMIT="836482e00c93618560c2896bbac87d3f89d17299"
+fi 
 
 src_prepare() {
 	# fix VideoCapture undefined reference error with opencv-3
@@ -72,7 +77,7 @@ src_prepare() {
 
 src_install() {
 	insinto /usr/share/nixnote2
-	doins -r certs help images java qss translations changelog.txt license.html shortcuts.txt *.ini
+	doins -r help images java qss translations changelog.txt license.html shortcuts.txt *.ini
 
 	rm -r ${D}/usr/share/nixnote2/translations/*.ts
 	


### PR DESCRIPTION
I try to add the socks5 proxy support which is a feature request described in issue #217. And as for nixnote2 can not be compiled against Qt4 after commit https://github.com/baumgarr/nixnote2/commit/3ea4ed4bfef90cc42a182167531e6f62a9e47c09 , the gentoo ebuild must be updated.