### PR TITLE
Install icon into /usr/share/pixmaps

### DIFF
--- a/NixNote2.pro
+++ b/NixNote2.pro
@@ -464,7 +464,11 @@ translations.files = translations/*
 qss.path = /usr/share/nixnote2/qss
 qss.files = qss/*
 
+pixmap.path = /usr/share/pixmaps/
+pixmap.extra = cp images/windowIcon.png images/nixnote2.png
+pixmap.files = images/nixnote2.png
+
 help.path = /usr/share/nixnote2/help
 help.files = help/*
 
-INSTALLS = binary desktop images java translations qss help
+INSTALLS = binary desktop images java translations qss pixmap help

--- a/nixnote2.desktop
+++ b/nixnote2.desktop
@@ -3,7 +3,7 @@ Name=NixNote2
 Comment=Use with Evernote to remember everything
 GenericName=Evernote-clone
 Exec=nixnote2
-Icon=/usr/share/nixnote2/images/windowIcon.png
+Icon=nixnote2
 StartupNotify=true
 Terminal=false
 Type=Application
@@ -13,5 +13,5 @@ Keywords=NixNote2;Text;Evernote;note;
 Actions=NewNote;
 [Desktop Action NewNote]
 Name=New Note
+Name[zh_CN]=新建笔记
 Exec=nixnote2 --newNote
-OnlyShowIn=Unity;


### PR DESCRIPTION
With this commit, the desktop file icon path will no longer be
hardcoded. This should conform to the requirement of Desktop
Entry Specification as released by freedesktop.org.

What's more, any third-party icon themes can now override default
nixnote2 icon through the mechanics described by the Specification
to alter the icon show on DE menu to fit their need.

Some extra modifications:

* `OnlyShowIn` is deprecated and useless so removed. Actually I am using GNOME Shell and this action also showed in my menu.
* Added a Simplified Chinese translation for that action.