### PR TITLE
Allow setting PREFIX during configure

### DIFF
--- a/NixNote2.pro
+++ b/NixNote2.pro
@@ -464,7 +464,11 @@ translations.files = translations/*
 qss.path = /usr/share/nixnote2/qss
 qss.files = qss/*
 
+pixmap.path = /usr/share/pixmaps/
+pixmap.extra = cp images/windowIcon.png images/nixnote2.png
+pixmap.files = images/nixnote2.png
+
 help.path = /usr/share/nixnote2/help
 help.files = help/*
 
-INSTALLS = binary desktop images java translations qss help
+INSTALLS = binary desktop images java translations qss pixmap help

--- a/NixNote2.pro
+++ b/NixNote2.pro
@@ -446,29 +446,33 @@ win32:QMAKE_CXXFLAGS +=-g -O2 --param=ssp-buffer-size=4 -Wformat -Werror=format-
 win32:QMAKE_LFLAGS += -Wl,-Bsymbolic-functions
 win32:DEFINES += SMTP_BUILD
 
-binary.path = /usr/bin/
+isEmpty(PREFIX) {
+    PREFIX = /usr/local
+}
+
+binary.path = $$PREFIX/bin/
 binary.files = nixnote2
 
-desktop.path = /usr/share/applications/
+desktop.path = $$PREFIX/share/applications/
 desktop.files = nixnote2.desktop
 
-images.path = /usr/share/nixnote2/images
+images.path = $$PREFIX/share/nixnote2/images
 images.files = images/*
 
-java.path = /usr/share/nixnote2/java
+java.path = $$PREFIX/share/nixnote2/java
 java.files = java/*
 
-translations.path = /usr/share/nixnote2/translations
+translations.path = $$PREFIX/share/nixnote2/translations
 translations.files = translations/*
 
-qss.path = /usr/share/nixnote2/qss
+qss.path = $$PREFIX/share/nixnote2/qss
 qss.files = qss/*
 
-pixmap.path = /usr/share/pixmaps/
+pixmap.path = $$PREFIX/share/pixmaps/
 pixmap.extra = cp images/windowIcon.png images/nixnote2.png
 pixmap.files = images/nixnote2.png
 
-help.path = /usr/share/nixnote2/help
+help.path = $$PREFIX/share/nixnote2/help
 help.files = help/*
 
 INSTALLS = binary desktop images java translations qss pixmap help

--- a/nixnote2.desktop
+++ b/nixnote2.desktop
@@ -3,7 +3,7 @@ Name=NixNote2
 Comment=Use with Evernote to remember everything
 GenericName=Evernote-clone
 Exec=nixnote2
-Icon=/usr/share/nixnote2/images/windowIcon.png
+Icon=nixnote2
 StartupNotify=true
 Terminal=false
 Type=Application
@@ -13,5 +13,5 @@ Keywords=NixNote2;Text;Evernote;note;
 Actions=NewNote;
 [Desktop Action NewNote]
 Name=New Note
+Name[zh_CN]=新建笔记
 Exec=nixnote2 --newNote
-OnlyShowIn=Unity;


### PR DESCRIPTION
This proposal should add the ability to use $$PREFIX to determine
where should we install the files, not hardcoded /usr/*.

After this commit, packagers need the following instructions to
build and install into /usr:

* qmake PREFIX=/usr .
* make
* sudo make install

Unfortunately this would break custom packaging_scripts **a lot**,
but this should be a cleaner approach to install files, either
for distribution maintainers or for upstream authors.

Also there are hardcoded detections for /usr/share/... in source
code and plugins. The impact of using a different PREFIX is yet
to be sorted out.

Any comment is welcomed.

P.S. This PR is based on previous one (#273) and supersedes previous PR.