### PR TITLE
fix include path for libtidy

### DIFF
--- a/html/enmlformatter.cpp
+++ b/html/enmlformatter.cpp
@@ -29,11 +29,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <QIcon>
 #include <QMessageBox>
 
-#include <tidy/tidy.h>
+#include <tidy.h>
 #ifndef _WIN32
-#include <tidy/buffio.h>
+#include <buffio.h>
 #else
-#include <tidy/tidybuffio.h>
+#include <tidybuffio.h>
 #endif
 
 #include <iostream>


### PR DESCRIPTION
According to [document of libtidy](http://www.html-tidy.org/developer/#developer20000401part_sample_program), the program using libtidy should use those include stmts:

```c
#include <tidy.h>
#include <tidybuffio.h>
```

So, I made this pr.
---
PS: I can compile in Fedora 25.