### PR TITLE
Improved "Restart sync on API limit" function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ Makefile.Release
 #eclipse files
 .cproject
 .settings
+
+cmake-build-debug/
+.idea/
+

--- a/communication/communicationmanager.h
+++ b/communication/communicationmanager.h
@@ -88,6 +88,8 @@ private:
     AuthenticationResult linkedAuth;          // Linked notebook authorization key
     QString linkedAuthToken;                  // linked notebook authorization token
 
+    qint32 minutesToNextSync;                    // After "API rate limit exceeded" how long should we wait to attempt sync notes (continue syncing large lists of notes - for example when user setup nixnote for first time)
+
 
     void downloadInkNoteImage(QString guid, Resource *r, QString shard, QString authToken);   // Function to download ink notes
     void checkForInkNotes(QList<Resource> &resources, QString shard, QString authToken);      // Check if a resource list has any ink notes
@@ -149,6 +151,8 @@ public:
     bool getNoteVersion(Note &note, QString guid, qint32 usn, bool withResourceData=true, bool withResourceRecognition=true, bool withResourceAlternateData=true);  // Download a past version of a note from a linked account
     void loadTagGuidMap();                                     // Load the tag hashmap.
     QString  errorWhat(QString what);                           // help build error string
+
+    qint32 getMinutesToNextSync();
 
 public slots:
     int inkNoteReady(QImage *newImage, QImage *replyImage, int position);   // An inknote has been downloaded.

--- a/global.cpp
+++ b/global.cpp
@@ -859,18 +859,189 @@ QString Global::getEditorBackgroundColor() {
         return "white";
 }
 
+QString Global::getNoteTitleColor() {
+    if (colorList.contains("noteTitleColor"))
+        return colorList["noteTitleColor"].trimmed();
+    else
+        return "#0e1cd1";
+}
+
+QString Global::getNoteTitleActiveStyle() {
+    QString result = this->getGenricStyle("titleActiveCss");
+
+    if(result.length() == 0)
+    {
+        result = "QLineEdit {border: 1px solid #808080; background-color: white; border-radius: 4px;} ";
+    }
+
+    return result;
+}
+
+QString Global::getNoteTitleInactiveStyle() {
+    QString result = this->getGenricStyle("titleInactiveCss");
+
+    if(result.length() == 0)
+    {
+        result = "QLineEdit {background-color: transparent; border-radius: 0px;} QLineEdit:hover {border: 1px solid #808080; background-color: white; border-radius: 4px;} ";
+    }
+
+    return result;
+}
+
+QString Global::getDateTimeEditorColor() {
+    if (colorList.contains("dateTimeEditorColor"))
+        return colorList["dateTimeEditorColor"].trimmed();
+    else
+        return "#0e1cd1";
+}
+
+QString Global::getTagViewerInactiveStyle() {
+    QString result = this->getGenricStyle("tagViewerInactiveCss");
+
+    if(result.length() == 0)
+    {
+        result = "QLineEdit {color: black; font:normal;} ";
+    }
+
+    return result;
+}
+
+
+QString Global::getTagViewerActiveStyle() {
+    QString result = this->getGenricStyle("tagViewerActiveCss");
+
+    if(result.length() == 0)
+    {
+        result = "QLineEdit {color: black; font:normal;} ";
+    }
+
+    return result;
+}
+
+
+QString Global::getTagEditorInactiveStyle() {
+    QString result = this->getGenricStyle("tagEditorInactiveCss");
+
+    if(result.length() == 0)
+    {
+        result = "QLineEdit {background-color: transparent; border-radius: 0px;} ";
+    }
+
+    return result;
+}
+
+
+QString Global::getTagEditorActiveStyle() {
+    QString result = this->getGenricStyle("tagEditorActiveCss");
+
+    if(result.length() == 0)
+    {
+        result = "QLineEdit {border: 1px solid #808080; background-color: white; border-radius: 4px;}";
+    }
+
+    return result;
+}
+
+
+
+
+QString Global::getUrlEditorActiveStyle() {
+    QString result = this->getGenricStyle("urlEditorActiveCss");
+
+    if(result.length() == 0)
+    {
+        result = "QLineEdit {border: 1px solid #808080; background-color: white; border-radius: 4px;}";
+    }
+
+    return result;
+}
+
+QString Global::getUrlEditorInactiveStyle() {
+    QString result = this->getGenricStyle("urlEditorInactiveCss");
+
+    if(result.length() == 0)
+    {
+        result = "QLineEdit {background-color: transparent; border-radius: 0px;}";
+    }
+
+    return result;
+}
+
+QString Global::getLineEditSearchActiveStyle() {
+    QString result = this->getGenricStyle("lineEditSearchActiveCss");
+
+    if(result.length() == 0)
+    {
+        result = "QLineEdit {color: black; font:normal;} ";
+    }
+
+    return result;
+}
+
+
+QString Global::getLineEditSearchInactiveStyle() {
+    QString result = this->getGenricStyle("lineEditSearchInactiveCss");
+
+    if(result.length() == 0)
+    {
+        result = "QLineEdit {color: gray; font:italic;} ";
+    }
+
+    return result;
+}
+
+
+QString Global::getDateTimeEditorActiveStyle() {
+    QString result = this->getGenricStyle("dateTimeEditorActiveCss");
+
+    if(result.length() == 0)
+    {
+        result = "QDateTimeEdit {border: 1px solid #808080; background-color: white; border-radius: 4px;}  QDateTimeEdit::up-button {width: 14px;} QDateTimeEdit::down-button{width: 14px;}";
+    }
+
+    return result;
+}
+
+QString Global::getDateTimeEditorInactiveStyle() {
+    QString result = this->getGenricStyle("dateTimeEditorInactiveCss");
+
+    if(result.length() == 0)
+    {
+       result = "QDateTimeEdit {background-color: transparent; border-radius: 1px;} QDateTimeEdit:hover {border: 1px solid #808080; background-color: white; border-radius: 4px;} QDateTimeEdit::up-button {width: 0px; image:none;} QDateTimeEdit::down-button{width: 0px; image: none;}";
+    }
+
+    return result;
+}
 
 QString Global::getEditorCss() {
-    QString css=fileManager.getQssDirPath("")+"editor.css";
-    if (colorList.contains("editorCss")) {
-        css = fileManager.getQssDirPathUser("")+colorList["editorCss"].trimmed();
-        if (QFile(css).exists())
-            return css;
-        css = fileManager.getQssDirPath("")+colorList["editorCss"].trimmed();
-        if (QFile(css).exists())
-            return css;
+    return this->getGenricCss("editorCss");
+}
+
+QString Global::getGenricStyle(QString key) {
+    QFile file(getGenricCss(key));
+    if(file.exists())
+    {
+        if(file.open(QFile::ReadOnly | QFile::Text))
+        {
+            QTextStream in(&file);
+            return in.readAll();
+        }
     }
-    return css;
+
+    return "";
+}
+
+QString Global::getGenricCss(QString key) {
+ QString css=fileManager.getQssDirPath("")+ key + ".css";
+ if (colorList.contains(key)) {
+     css = fileManager.getQssDirPathUser("")+colorList[key].trimmed();
+     if (QFile(css).exists())
+         return css;
+     css = fileManager.getQssDirPath("")+colorList[key].trimmed();
+     if (QFile(css).exists())
+         return css;
+ }
+ return css;
 }
 
 
@@ -958,7 +1129,7 @@ void Global::loadThemeFile(QHash<QString,QString> &resourceList, QHash<QString,Q
                         resourceList.insert(":"+key,value);
                     } else {
                         colorList.remove("key");
-                        colorList.insert(key,value);
+                        colorList.insert(key, fields[1].simplified());
                     }
                 }
             }

--- a/global.h
+++ b/global.h
@@ -259,6 +259,30 @@ public:
     QString getEditorStyle(bool colorOnly);                // Get note editor style overrides
     QString getEditorFontColor();                           // Get the editor font color from the theme
     QString getEditorBackgroundColor();                     // Get the editor background color from the theme
+
+    QString getGenricCss(QString key);
+    QString getGenricStyle(QString key);
+
+    QString getNoteTitleColor();
+    QString getNoteTitleActiveStyle();
+    QString getNoteTitleInactiveStyle();
+
+    QString getTagViewerActiveStyle();
+    QString getTagViewerInactiveStyle();
+
+    QString getTagEditorActiveStyle();
+    QString getTagEditorInactiveStyle();
+
+    QString getUrlEditorActiveStyle();
+    QString getUrlEditorInactiveStyle();
+
+    QString getLineEditSearchActiveStyle();
+    QString getLineEditSearchInactiveStyle();
+
+    QString getDateTimeEditorColor();
+    QString getDateTimeEditorActiveStyle();
+    QString getDateTimeEditorInactiveStyle();
+
     QString getEditorCss();
     QPixmap getPixmapResource(QHash<QString, QString> &resourceList, QString key);   // Get a pixmap from the user's (or default) theme
     QPixmap getPixmapResource(QString key);                   // Get a pixmap from the user's (or default) theme

--- a/gui/browserWidgets/datetimeeditor.cpp
+++ b/gui/browserWidgets/datetimeeditor.cpp
@@ -36,12 +36,13 @@ DateTimeEditor::DateTimeEditor(QWidget *parent) :
     this->setFont(global.getGuiFont(font()));
 
     QPalette pal;
-    pal.setColor(QPalette::Text, QColor(14,28,209));
+    QString test = global.getDateTimeEditorColor();
+    pal.setColor(QPalette::Text, QColor(test));
     pal.setColor(backgroundRole(), QPalette::Base);
     setPalette(pal);
 
-    inactiveColor = "QDateTimeEdit {background-color: transparent; border-radius: 1px;} QDateTimeEdit:hover {border: 1px solid #808080; background-color: white; border-radius: 4px;} QDateTimeEdit::up-button {width: 0px; image:none;} QDateTimeEdit::down-button{width: 0px; image: none;}";
-    activeColor = "QDateTimeEdit {border: 1px solid #808080; background-color: white; border-radius: 4px;}  QDateTimeEdit::up-button {width: 14px;} QDateTimeEdit::down-button{width: 14px;}";
+    inactiveColor = global.getDateTimeEditorInactiveStyle();
+    activeColor = global.getDateTimeEditorActiveStyle();
 
     //editor.setCalendarPopup(true);
     //display.setStyleSheet(inactiveColor);

--- a/gui/browserWidgets/ntitleeditor.cpp
+++ b/gui/browserWidgets/ntitleeditor.cpp
@@ -33,13 +33,13 @@ NTitleEditor::NTitleEditor(QWidget *parent) :
 {
     // Setup the note title editor
     QPalette pal;
-    //pal.setColor(QPalette::Text, QColor(102,153,255));
-    pal.setColor(QPalette::Text, QColor(14,28,209));
+    pal.setColor(QPalette::Text, QColor(global.getNoteTitleColor()));
     pal.setColor(backgroundRole(), QPalette::Base);
     setPalette(pal);
 
-    inactiveColor = "QLineEdit {background-color: transparent; border-radius: 0px;} QLineEdit:hover {border: 1px solid #808080; background-color: white; border-radius: 4px;} ";
-    activeColor = "QLineEdit {border: 1px solid #808080; background-color: white; border-radius: 4px;} ";
+    inactiveColor = global.getNoteTitleInactiveStyle();
+    activeColor = global.getNoteTitleActiveStyle();
+
     this->setStyleSheet(inactiveColor);
     connect(this, SIGNAL(textChanged(QString)), this, SLOT(titleChanged(QString)));
 

--- a/gui/browserWidgets/tageditornewtag.cpp
+++ b/gui/browserWidgets/tageditornewtag.cpp
@@ -48,8 +48,8 @@ TagEditorNewTag::TagEditorNewTag(QWidget *parent) :
 
     this->setFont(global.getGuiFont(font()));
 
-    inactiveColor = "QLineEdit {background-color: transparent; border-radius: 0px;} ";
-    activeColor = "QLineEdit {border: 1px solid #808080; background-color: white; border-radius: 4px;} ";
+    inactiveColor = global.getTagEditorInactiveStyle();
+    activeColor = global.getTagEditorActiveStyle();
     this->setStyleSheet(inactiveColor);
 
     this->setPlaceholderText(tr("Click to add tag..."));

--- a/gui/browserWidgets/urleditor.cpp
+++ b/gui/browserWidgets/urleditor.cpp
@@ -37,8 +37,8 @@ UrlEditor::UrlEditor(QWidget *parent) :
 
     this->setFont(global.getGuiFont(font()));
 
-    inactiveColor = "QLineEdit {background-color: transparent; border-radius: 0px;} ";
-    activeColor = "QLineEdit {border: 1px solid #808080; background-color: white; border-radius: 4px;} ";
+    inactiveColor = global.getUrlEditorInactiveStyle();
+    activeColor = global.getUrlEditorActiveStyle();
     this->setCursor(Qt::PointingHandCursor);
     this->setStyleSheet(inactiveColor);
 

--- a/gui/lineedit.cpp
+++ b/gui/lineedit.cpp
@@ -39,8 +39,8 @@ extern Global global;
      defaultText = QString(tr("Search"));
      this->setText(defaultText);
 
-     inactiveColor = "QLineEdit {color: gray; font:italic;} ";
-     activeColor = "QLineEdit {color: black; font:normal;} ";
+     inactiveColor = global.getLineEditSearchInactiveStyle();
+     activeColor = global.getLineEditSearchActiveStyle();
 
      connect(this, SIGNAL(returnPressed()), this, SLOT(buildSelection()));
      connect(this, SIGNAL(textChanged(QString)), this, SLOT(textChanged(QString)));

--- a/nixnote.cpp
+++ b/nixnote.cpp
@@ -1487,9 +1487,7 @@ void NixNote::syncButtonReset() {
            bool restart = global.settings->value("apiRateLimitAutoRestart", false).toBool();
            global.settings->endGroup();
            if (restart) {
-               QTime t = QTime::currentTime();
-               int minutes = 60-t.minute()+1; // Time to the top of the hour plus a padding.
-               QTimer::singleShot(60*1000*minutes, this, SLOT(synchronize()));
+               QTimer::singleShot(60*1000* (syncRunner.minutesToNextSync + 1), this, SLOT(synchronize()));
            }
     }
 }
@@ -1912,7 +1910,13 @@ void NixNote::notifySyncComplete() {
         return;
     if (syncRunner.error) {
         showMessage(tr("Sync Error"), tr("Sync completed with errors."));
-        if (global.popupOnSyncError()) {
+
+        global.settings->beginGroup("Sync");
+        bool isAutoRestartEnabled = global.settings->value("apiRateLimitAutoRestart", false).toBool();
+        global.settings->endGroup();
+
+        //Do not show popup when automatic sync after error enabled
+        if (global.popupOnSyncError() && !isAutoRestartEnabled) {
             QMessageBox::critical(0, tr("Sync Error"), tr("Sync error. See message log for details"));
         }
     } else

--- a/qss/editor_dark.css
+++ b/qss/editor_dark.css
@@ -6,3 +6,7 @@ body {
 a {
     color: lightblue;
 }
+
+img {
+    background-color: white;
+}

--- a/qss/mint_dark_y.css
+++ b/qss/mint_dark_y.css
@@ -1,0 +1,8 @@
+body { 
+  background-color: #2B2B2B;
+  color: white;
+}
+
+a {
+    color: lightblue;
+}

--- a/qss/mint_dark_y_datetime_active.css
+++ b/qss/mint_dark_y_datetime_active.css
@@ -1,0 +1,21 @@
+QDateTimeEdit {
+    background-color: transparent;
+    border-radius: 1px;
+}
+
+QDateTimeEdit:hover {
+    border: 1px solid #8e8e8e;
+    color: #ededed;
+    background-color: transparent;
+    border-radius: 4px;
+}
+
+QDateTimeEdit::up-button {
+    width: 0px;
+    image: none;
+}
+
+QDateTimeEdit::down-button {
+    width: 0px;
+    image: none;
+}

--- a/qss/mint_dark_y_datetime_inactive.css
+++ b/qss/mint_dark_y_datetime_inactive.css
@@ -1,0 +1,13 @@
+QDateTimeEdit {
+    border: 1px solid transparent;
+    background-color: transparent;
+    border-radius: 4px;
+}
+
+QDateTimeEdit::up-button {
+    width: 14px;
+}
+
+QDateTimeEdit::down-button {
+    width: 14px;
+}

--- a/qss/mint_dark_y_search_active.css
+++ b/qss/mint_dark_y_search_active.css
@@ -1,0 +1,1 @@
+QLineEdit {color: white; font:normal;}

--- a/qss/mint_dark_y_search_inactive.css
+++ b/qss/mint_dark_y_search_inactive.css
@@ -1,0 +1,1 @@
+QLineEdit {color: #aab1ff; font:italic;}

--- a/qss/mint_dark_y_tagedit_active.css
+++ b/qss/mint_dark_y_tagedit_active.css
@@ -1,0 +1,6 @@
+QLineEdit {
+    border: 1px solid #808080;
+    background-color: transparent;
+    color: white;
+    border-radius: 4px;
+}

--- a/qss/mint_dark_y_tagedit_inactive.css
+++ b/qss/mint_dark_y_tagedit_inactive.css
@@ -1,0 +1,4 @@
+QLineEdit {
+    background-color: transparent;
+    border-radius: 0px;
+}

--- a/qss/mint_dark_y_title_active.css
+++ b/qss/mint_dark_y_title_active.css
@@ -1,0 +1,12 @@
+QLineEdit {
+    background-color: transparent;
+    border-radius: 0px;
+    color: #ededed;
+}
+
+QLineEdit:hover {
+    border: 1px solid #8e8e8e;
+    color: #ededed;
+    background-color: transparent;
+    border-radius: 4px;
+}

--- a/qss/mint_dark_y_title_inactive.css
+++ b/qss/mint_dark_y_title_inactive.css
@@ -1,0 +1,6 @@
+QLineEdit {
+    border: none;
+    background-color: transparent;
+    border-radius: 4px;
+    color: #aab1ff;
+}

--- a/qss/mint_dark_y_urledit_active.css
+++ b/qss/mint_dark_y_urledit_active.css
@@ -1,0 +1,6 @@
+QLineEdit {
+    border: 1px solid #808080;
+    background-color: transparent;
+    color: white;
+    border-radius: 4px;
+}

--- a/qss/mint_dark_y_urledit_inactive.css
+++ b/qss/mint_dark_y_urledit_inactive.css
@@ -1,0 +1,4 @@
+QLineEdit {
+    background-color: transparent;
+    border-radius: 0px;
+}

--- a/settings/filemanager.cpp
+++ b/settings/filemanager.cpp
@@ -69,7 +69,6 @@ void FileManager::setup(QString homeDirPath, QString programDirPath, int id) {
     checkExistingReadableDir(qssDir);
     qssDirPath = slashTerminatePath(qssDir.path());
 
-
     // Read/write directories that only we use
 
     QString settingsFile = getHomeDirPath("") + "nixnote.conf";

--- a/theme.ini
+++ b/theme.ini
@@ -133,6 +133,24 @@ editorFontColor=white
 editorBackgroundColor=black
 editorCss=editor_dark.css
 
+[Mint Dark Y Theme]
+editorFontColor=white
+editorBackgroundColor=#2B2B2B
+noteTitleColor=#aab1ff
+dateTimeEditorColor=#aab1ff
+editorCss=mint_dark_y.css
+titleActiveCss=mint_dark_y_title_active.css
+titleInactiveCss=mint_dark_y_title_inactive.css
+dateTimeEditorActiveCss=mint_dark_y_datetime_active.css
+dateTimeEditorInactiveCss=mint_dark_y_datetime_inactive.css
+lineEditSearchActiveCss=mint_dark_y_search_active.css
+lineEditSearchInactiveCss=mint_dark_y_search_inactive.css
+tagViewerInactiveCss=mint_dark_y_tagviewer_inactive.css
+tagViewerActiveCss=mint_dark_y_tagviewer_active.css
+tagEditorInactiveCss=mint_dark_y_tagedit_inactive.css
+tagEditorActiveCss=mint_dark_y_tagedit_active.css
+urlEditorActiveCss=mint_dark_y_urledit_inactive.css
+urlEditorInactiveCss=mint_dark_y_urledit_active.css
 
 #[SampleTheme]
 #windowIcon=/usr/share/nixnote2/images/windowIcon0.png                   # Main window icon

--- a/threads/syncrunner.cpp
+++ b/threads/syncrunner.cpp
@@ -42,6 +42,7 @@ SyncRunner::SyncRunner()
     init = false;
     finalSync = false;
     apiRateLimitExceeded=false;
+    minutesToNextSync=0;
 }
 
 SyncRunner::~SyncRunner() {
@@ -1214,6 +1215,7 @@ void SyncRunner::communicationErrorHandler() {
         else
             emitMsg = "API rate limit exceeded.  Please try again in one hour.";
         emit(setMessage(emitMsg, 0));
+        minutesToNextSync = comm->getMinutesToNextSync();
         apiRateLimitExceeded = true;
         return;
     }

--- a/threads/syncrunner.h
+++ b/threads/syncrunner.h
@@ -107,7 +107,10 @@ public:
     CommunicationError* getError();
     void communicationErrorHandler();
     bool finalSync;
+
     bool apiRateLimitExceeded;
+    qint32 minutesToNextSync;                    // After "API rate limit exceeded" how long should we wait to attempt sync notes (continue syncing large lists of notes - for example when user setup nixnote for first time)
+
 
 signals:
     void syncComplete();


### PR DESCRIPTION
I just moved from Windows based Evernote client to nix note and sync is a pain with current version.

Implemented proper way to sync notes after "API rate limit exceeded". Now it will ensure that notes will be synced as soon as possible. In my case without this update as a new user it will take forever to sync +10k notes by repeated press of Sync button or improper time intervals by hour as it was before. 

In preferences must be enabled Sync > Restart sync on API limit (experimental)

I also advise to enable this function by default for new users.