### PR TITLE
Eliminate the compiler warnings when implicit type conversion

### DIFF
--- a/global.cpp
+++ b/global.cpp
@@ -217,8 +217,8 @@ void Global::setup(StartupConfig startupConfig, bool guiAvailable) {
         // QWebkit DPI is hard coded to 96. Hence, we calculate the correct
         // font size based on desktop logical DPI.
         settings->setFontSize(QWebSettings::DefaultFontSize,
-            defaultFontSize * (QApplication::desktop()->logicalDpiX() / 96.0)
-            );
+            int(defaultFontSize * (QApplication::desktop()->logicalDpiX() / 96.0))
+            );	
     }
     if (defaultFont != "" && defaultFontSize <= 0 && this->guiAvailable) {
         QWebSettings *settings = QWebSettings::globalSettings();

--- a/global.cpp
+++ b/global.cpp
@@ -218,7 +218,7 @@ void Global::setup(StartupConfig startupConfig, bool guiAvailable) {
         // font size based on desktop logical DPI.
         settings->setFontSize(QWebSettings::DefaultFontSize,
             int(defaultFontSize * (QApplication::desktop()->logicalDpiX() / 96.0))
-            );	
+            );
     }
     if (defaultFont != "" && defaultFontSize <= 0 && this->guiAvailable) {
         QWebSettings *settings = QWebSettings::globalSettings();

--- a/main.cpp
+++ b/main.cpp
@@ -276,7 +276,7 @@ int main(int argc, char *argv[])
         if (host.trimmed() != "")
             proxy.setHostName(host.trimmed());
         if (port > 0)
-            proxy.setPort(port);
+            proxy.setPort(quint16(port));
         if (user.trimmed() != "")
             proxy.setUser(user.trimmed());
         if (password.trimmed() != "")


### PR DESCRIPTION
Eliminate the compiler warnings when implicit type conversion
implicit conversion loses interger precision 'int' to 'quint16'
implicit conversion turns floating-point number into interger
